### PR TITLE
empty title means no title (logo only), so title header doesn't take space

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Property |   Type     | Desciption
 onSignup |   `AuthCallback`     | <sub>Called when the user hit the submit button when in sign up mode</sub>
 onLogin |   `AuthCallback`     | <sub>Called when the user hit the submit button when in login mode</sub>
 onRecoverPassword |   `RecoverCallback`     | <sub>Called when the user hit the submit button when in recover password mode</sub>
-title |   `String`     | <sub>The large text above the login [Card], usually the app or company name</sub>
+title |   `String`     | <sub>The large text above the login [Card], usually the app or company name, or empty string for no title</sub>
 logo |   `String`     | <sub>The path to the asset image that will be passed to the `Image.asset()`</sub>
 messages |   [`LoginMessages`](#LoginMessages)     | <sub>Describes all of the labels, text hints, button texts and other auth descriptions</sub>
 theme |   [`LoginTheme`](#LoginTheme)     | <sub>FlutterLogin's theme. If not specified, it will use the default theme as shown in the demo gifs and use the colorsheme in the closest `Theme` widget</sub>

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Property |   Type     | Desciption
 onSignup |   `AuthCallback`     | <sub>Called when the user hit the submit button when in sign up mode</sub>
 onLogin |   `AuthCallback`     | <sub>Called when the user hit the submit button when in login mode</sub>
 onRecoverPassword |   `RecoverCallback`     | <sub>Called when the user hit the submit button when in recover password mode</sub>
-title |   `String`     | <sub>The large text above the login [Card], usually the app or company name, or empty string for no title</sub>
+title |   `String`     | <sub>The large text above the login [Card], usually the app or company name. Leave the string empty or null if you want no title.</sub>
 logo |   `String`     | <sub>The path to the asset image that will be passed to the `Image.asset()`</sub>
 messages |   [`LoginMessages`](#LoginMessages)     | <sub>Describes all of the labels, text hints, button texts and other auth descriptions</sub>
 theme |   [`LoginTheme`](#LoginTheme)     | <sub>FlutterLogin's theme. If not specified, it will use the default theme as shown in the demo gifs and use the colorsheme in the closest `Theme` widget</sub>

--- a/example/lib/login_screen.dart
+++ b/example/lib/login_screen.dart
@@ -40,10 +40,10 @@ class LoginScreen extends StatelessWidget {
     );
 
     return FlutterLogin(
-      title: '',
+      title: Constants.appName,
       logo: 'assets/images/ecorp.png',
       logoTag: Constants.logoTag,
-      titleTag: null,
+      titleTag: Constants.titleTag,
       // messages: LoginMessages(
       //   usernameHint: 'Username',
       //   passwordHint: 'Pass',

--- a/example/lib/login_screen.dart
+++ b/example/lib/login_screen.dart
@@ -40,10 +40,10 @@ class LoginScreen extends StatelessWidget {
     );
 
     return FlutterLogin(
-      title: Constants.appName,
+      title: '',
       logo: 'assets/images/ecorp.png',
       logoTag: Constants.logoTag,
-      titleTag: Constants.titleTag,
+      titleTag: null,
       // messages: LoginMessages(
       //   usernameHint: 'Username',
       //   passwordHint: 'Pass',

--- a/lib/flutter_login.dart
+++ b/lib/flutter_login.dart
@@ -8,6 +8,7 @@ import 'package:provider/provider.dart';
 import 'src/providers/login_theme.dart';
 import 'src/widgets/null_widget.dart';
 import 'theme.dart';
+import 'src/dart_helper.dart';
 import 'src/color_helper.dart';
 import 'src/providers/auth.dart';
 import 'src/providers/login_messages.dart';
@@ -103,7 +104,7 @@ class _Header extends StatelessWidget {
     }
 
     Widget header;
-    if (titleTag != null && title.isNotEmpty) {
+    if (titleTag != null && !DartHelper.isNullOrEmpty(title)) {
       header = HeroText(
         title,
         tag: titleTag,
@@ -112,7 +113,7 @@ class _Header extends StatelessWidget {
         style: theme.textTheme.display2,
         viewState: ViewState.enlarged,
       );
-    } else if (title.isNotEmpty) {
+    } else if (!DartHelper.isNullOrEmpty(title)) {
       header = Text(
         title,
         style: theme.textTheme.display2,

--- a/lib/flutter_login.dart
+++ b/lib/flutter_login.dart
@@ -103,8 +103,7 @@ class _Header extends StatelessWidget {
     }
 
     Widget header;
-
-    if (titleTag != null) {
+    if (titleTag != null && title.isNotEmpty) {
       header = HeroText(
         title,
         tag: titleTag,
@@ -113,11 +112,13 @@ class _Header extends StatelessWidget {
         style: theme.textTheme.display2,
         viewState: ViewState.enlarged,
       );
-    } else {
+    } else if (title.isNotEmpty) {
       header = Text(
         title,
         style: theme.textTheme.display2,
       );
+    } else {
+      header = null;
     }
 
     return SizedBox(


### PR DESCRIPTION
When title is empty, this removes the empty space where title would normally be so that the logo spacing looks good.