### PR TITLE
fix color index crash that happens when app theme has no primarySwatch

### DIFF
--- a/lib/flutter_login.dart
+++ b/lib/flutter_login.dart
@@ -373,7 +373,7 @@ class _FlutterLoginState extends State<FlutterLogin>
         : primaryDarkShades.first;
     final primaryColorDark = primaryDarkShades.length >= 3
         ? primaryDarkShades[2]
-        : primaryDarkShades[1];
+        : primaryDarkShades.last;
     final accentColor = loginTheme.accentColor ?? theme.accentColor;
     final errorColor = loginTheme.errorColor ?? theme.errorColor;
     // the background is a dark gradient, force to use white text if detect default black text color


### PR DESCRIPTION
When app's theme sets primaryColor instead of primarySwatch, a crash can happen depending on the color and shade. Crash happens, for example, with primaryColor: Colors.grey[300] like this:

```
class MyApp extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Login Demo',
      theme: ThemeData(
        primaryColor: Colors.grey[300],
        accentColor: Colors.orange,
        cursorColor: Colors.orange,
        ...
```
Crash trace is like this:

```
I/flutter (15300): RangeError (index): Invalid value: Only valid value is 0: 1
I/flutter (15300): 
I/flutter (15300): User-created ancestor of the error-causing widget was:
I/flutter (15300):   LoginScreen
I/flutter (15300):   file:///Users/ryanjones/Development/Work/flutter_login_ui/flutter_login/example/lib/main.dart:58:13
I/flutter (15300): 
I/flutter (15300): When the exception was thrown, this was the stack:
I/flutter (15300): #0      List.[] (dart:core-patch/growable_array.dart:147:60)
I/flutter (15300): #1      _FlutterLoginState._mergeTheme (package:flutter_login/flutter_login.dart:377:28)
I/flutter (15300): #2      _FlutterLoginState.build (package:flutter_login/flutter_login.dart:481:19)
I/flutter (15300): #3      StatefulElement.build (package:flutter/src/widgets/framework.dart:4047:27)
```
