### PR TITLE
Optional config for login screen background color gradients (independent of primaryColor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ textFieldStyle | `TextStyle` | Text style for [TextField] input text
 buttonStyle | `TextStyle` | Text style for button text
 beforeHeroFontSize | `double` | Defines the font size of the title in the login screen (before the hero transition)
 afterHeroFontSize | `double` | Defines the font size of the title in the screen after the login screen (after the hero transition)
+pageColorLight | `Color` | The optional light background color of login screen; if provided, used for light gradient instead of primaryColor
+pageColorDark | `Color` | The optional dark background color of login screen; if provided, used for dark gradient instead of primaryColor
+
 
 ## Examples
 

--- a/lib/flutter_login.dart
+++ b/lib/flutter_login.dart
@@ -515,7 +515,10 @@ class _FlutterLoginState extends State<FlutterLogin>
         body: Stack(
           children: <Widget>[
             GradientBox(
-              colors: [theme.primaryColor, theme.primaryColorDark],
+              colors: [
+                loginTheme.pageColorLight ?? theme.primaryColor,
+                loginTheme.pageColorDark ?? theme.primaryColorDark,
+              ],
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
             ),

--- a/lib/src/providers/login_theme.dart
+++ b/lib/src/providers/login_theme.dart
@@ -54,11 +54,11 @@ class LoginTheme with ChangeNotifier {
     this.afterHeroFontSize = 15.0,
   });
 
-  /// The background color of the login page for light gradient; if specified,
+  /// The background color of the login page for light gradient; if provided,
   /// overrides the [primaryColor] for page background
   final Color pageColorLight;
 
-  /// The background color of the login page for dark gradient; if specified,
+  /// The background color of the login page for dark gradient; if provided,
   /// overrides the computed primaryColorDark for page background
   final Color pageColorDark;
 

--- a/lib/src/providers/login_theme.dart
+++ b/lib/src/providers/login_theme.dart
@@ -36,6 +36,8 @@ class LoginButtonTheme {
 
 class LoginTheme with ChangeNotifier {
   LoginTheme({
+    this.pageColorLight,
+    this.pageColorDark,
     this.primaryColor,
     this.accentColor,
     this.errorColor,
@@ -51,6 +53,14 @@ class LoginTheme with ChangeNotifier {
     this.beforeHeroFontSize = 48.0,
     this.afterHeroFontSize = 15.0,
   });
+
+  /// The background color of the login page for light gradient; if specified,
+  /// overrides the [primaryColor] for page background
+  final Color pageColorLight;
+
+  /// The background color of the login page for dark gradient; if specified,
+  /// overrides the computed primaryColorDark for page background
+  final Color pageColorDark;
 
   /// The background color of major parts of the widget like the login screen
   /// and buttons


### PR DESCRIPTION
This change is to add an optional LoginTheme config for the login screen's light and dark background color gradients. If provided, the pageColorLight and pageColorDark color values will override the primaryColor and computed primaryColorDark values for the light and dark gradients used on the login screen background.

The reason is that you might want a lighter background color than what is used for your primary color in the form field backgrounds, etc. Also, when using a lighter color for your primaryColor, the computed primaryColorDark often doesn't actually provide a darker color, so you don't get any gradient effect at all. Anyhow, a lighter primaryColor can cause the form fields to blend into the white auth_card background, with not enough visible contrast.

So, this is just one potential way to give users more control with LoginTheme config options.