### PR TITLE
share email input between login and recovery cards

### DIFF
--- a/lib/src/providers/auth.dart
+++ b/lib/src/providers/auth.dart
@@ -34,6 +34,8 @@ class Auth with ChangeNotifier {
   final AuthCallback onSignup;
   final RecoverCallback onRecoverPassword;
 
+  var _authData = {'email': '', 'password': ''};
+
   AuthMode _mode = AuthMode.Login;
 
   AuthMode get mode => _mode;
@@ -57,5 +59,17 @@ class Auth with ChangeNotifier {
       mode = AuthMode.Login;
     }
     return mode;
+  }
+
+  get email => _authData['email'];
+  set email(String email) {
+    _authData['email'] = email;
+    notifyListeners();
+  }
+
+  get password => _authData['password'];
+  set password(String password) {
+    _authData['password'] = password;
+    notifyListeners();
   }
 }

--- a/lib/src/providers/auth.dart
+++ b/lib/src/providers/auth.dart
@@ -19,6 +19,8 @@ class Auth with ChangeNotifier {
   }) {
     if (previous != null) {
       _mode = previous.mode;
+      _authData['email'] = previous.email;
+      _authData['password'] = previous.password;
     }
   }
 

--- a/lib/src/widgets/auth_card.dart
+++ b/lib/src/widgets/auth_card.dart
@@ -512,8 +512,6 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
   }
 
   Widget _buildPasswordField(double width, LoginMessages messages, Auth auth) {
-    final auth = Provider.of<Auth>(context);
-
     return AnimatedPasswordTextFormField(
       animatedWidth: width,
       loadingController: _loadingController,
@@ -536,9 +534,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
     );
   }
 
-  Widget _buildConfirmPasswordField(double width, LoginMessages messages) {
-    final auth = Provider.of<Auth>(context);
-
+  Widget _buildConfirmPasswordField(double width, LoginMessages messages, Auth auth) {
     return AnimatedPasswordTextFormField(
       animatedWidth: width,
       enabled: auth.isSignup,
@@ -581,9 +577,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
     );
   }
 
-  Widget _buildSubmitButton(ThemeData theme, LoginMessages messages) {
-    final auth = Provider.of<Auth>(context);
-
+  Widget _buildSubmitButton(ThemeData theme, LoginMessages messages, Auth auth) {
     return ScaleTransition(
       scale: _buttonScaleAnimation,
       child: AnimatedButton(
@@ -594,9 +588,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
     );
   }
 
-  Widget _buildSwitchAuthButton(ThemeData theme, LoginMessages messages) {
-    final auth = Provider.of<Auth>(context, listen: false);
-
+  Widget _buildSwitchAuthButton(ThemeData theme, LoginMessages messages, Auth auth) {
     return FadeIn(
       controller: _loadingController,
       offset: .5,
@@ -661,7 +653,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
               vertical: 10,
             ),
             onExpandCompleted: () => _postSwitchAuthController.forward(),
-            child: _buildConfirmPasswordField(textFieldWidth, messages),
+            child: _buildConfirmPasswordField(textFieldWidth, messages, auth),
           ),
           Container(
             padding: Paddings.fromRBL(cardPadding),
@@ -669,8 +661,8 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
             child: Column(
               children: <Widget>[
                 _buildForgotPassword(theme, messages),
-                _buildSubmitButton(theme, messages),
-                _buildSwitchAuthButton(theme, messages),
+                _buildSubmitButton(theme, messages, auth),
+                _buildSwitchAuthButton(theme, messages, auth),
               ],
             ),
           ),


### PR DESCRIPTION
This change is to share the email field input between the login and recovery cards. When the user updates the email field on either card, it will update on the other card too.

The main advantage is to pre-populate the recovery card, so the user won't have to re-type their email address if they already entered it on the login card.

Email and password are now kept in the Auth provider. Both login and recovery cards now listen for Auth updates.
