### PR TITLE
adjust button width if needed to accommodate longer label text

### DIFF
--- a/example/lib/login_screen.dart
+++ b/example/lib/login_screen.dart
@@ -44,6 +44,9 @@ class LoginScreen extends StatelessWidget {
       logo: 'assets/images/ecorp.png',
       logoTag: Constants.logoTag,
       titleTag: Constants.titleTag,
+      messages: LoginMessages(
+        loginButton: 'HOW IS THIS?',
+      ),
       // messages: LoginMessages(
       //   usernameHint: 'Username',
       //   passwordHint: 'Pass',

--- a/example/lib/login_screen.dart
+++ b/example/lib/login_screen.dart
@@ -44,9 +44,6 @@ class LoginScreen extends StatelessWidget {
       logo: 'assets/images/ecorp.png',
       logoTag: Constants.logoTag,
       titleTag: Constants.titleTag,
-      messages: LoginMessages(
-        loginButton: 'HOW IS THIS?',
-      ),
       // messages: LoginMessages(
       //   usernameHint: 'Username',
       //   passwordHint: 'Pass',

--- a/lib/src/widgets/animated_button.dart
+++ b/lib/src/widgets/animated_button.dart
@@ -34,8 +34,8 @@ class _AnimatedButtonState extends State<AnimatedButton>
   Animation<Color> _colorAnimation;
   var _isLoading = false;
   var _hover = false;
+  var _width = -1.0;
 
-  double _width;
   Color _color;
   Color _loadingColor;
 
@@ -47,35 +47,12 @@ class _AnimatedButtonState extends State<AnimatedButton>
   void initState() {
     super.initState();
 
-    var renderParagraph = RenderParagraph(
-      TextSpan(
-        text: widget.text,
-      ),
-      textDirection: TextDirection.ltr,
-      maxLines: 1,
-    );
-
-    renderParagraph.layout(BoxConstraints(minWidth: 120.0));
-
-    // text width based on fontSize 12, plus 24.0 for padding
-    var textWidth = renderParagraph.getMinIntrinsicWidth(12).ceilToDouble() + 24.0;
-
-    // button width is min 120.0 and max 240.0
-    _width = textWidth > 120.0 && textWidth < 240.0 ? textWidth :
-        textWidth >= 240.0 ? 240.0 : 120.0;
-
     _textOpacityAnimation = Tween<double>(begin: 1.0, end: 0.0).animate(
       CurvedAnimation(
         parent: widget.controller,
         curve: Interval(0.0, .25),
       ),
     );
-
-    _sizeAnimation = Tween<double>(begin: 1.0, end: _height / _width)
-        .animate(CurvedAnimation(
-      parent: widget.controller,
-      curve: Interval(0.0, .65, curve: Curves.fastOutSlowIn),
-    ));
 
     // _colorAnimation
 
@@ -149,6 +126,40 @@ class _AnimatedButtonState extends State<AnimatedButton>
     }
   }
 
+  // initializes width and size animation
+  void _initWidth(BuildContext context) {
+    final theme = Theme.of(context);
+    final fontSize = theme.textTheme.button.fontSize;
+
+    var renderParagraph = RenderParagraph(
+      TextSpan(
+        text: widget.text,
+        style: TextStyle(
+          fontSize: fontSize,
+          fontWeight: theme.textTheme.button.fontWeight,
+          letterSpacing: theme.textTheme.button.letterSpacing,
+        ),
+      ),
+      textDirection: TextDirection.ltr,
+      maxLines: 1,
+    );
+
+    renderParagraph.layout(BoxConstraints(minWidth: 120.0));
+
+    // text width based on fontSize, plus 24.0 for padding
+    var textWidth = renderParagraph.getMinIntrinsicWidth(fontSize).ceilToDouble() + 24.0;
+
+    // button width is min 120.0 and max 240.0
+    _width = textWidth > 120.0 && textWidth < 240.0 ? textWidth :
+      textWidth >= 240.0 ? 240.0 : 120.0;
+
+    _sizeAnimation = Tween<double>(begin: 1.0, end: _height / _width)
+        .animate(CurvedAnimation(
+      parent: widget.controller,
+      curve: Interval(0.0, .65, curve: Curves.fastOutSlowIn),
+    ));
+  }
+
   Widget _buildButtonText(ThemeData theme) {
     return FadeTransition(
       opacity: _textOpacityAnimation,
@@ -161,6 +172,10 @@ class _AnimatedButtonState extends State<AnimatedButton>
 
   Widget _buildButton(ThemeData theme) {
     final buttonTheme = theme.floatingActionButtonTheme;
+
+    if (_width < 0) {
+      _initWidth(context);
+    }
 
     return FadeTransition(
       opacity: _buttonOpacityAnimation,

--- a/lib/src/widgets/animated_button.dart
+++ b/lib/src/widgets/animated_button.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'animated_text.dart';
 import 'ring.dart';
 
@@ -33,10 +35,10 @@ class _AnimatedButtonState extends State<AnimatedButton>
   var _isLoading = false;
   var _hover = false;
 
+  double _width;
   Color _color;
   Color _loadingColor;
 
-  static const _width = 120.0;
   static const _height = 40.0;
   static const _loadingCircleRadius = _height / 2;
   static const _loadingCircleThickness = 4.0;
@@ -44,6 +46,23 @@ class _AnimatedButtonState extends State<AnimatedButton>
   @override
   void initState() {
     super.initState();
+
+    var renderParagraph = RenderParagraph(
+      TextSpan(
+        text: widget.text,
+      ),
+      textDirection: TextDirection.ltr,
+      maxLines: 1,
+    );
+
+    renderParagraph.layout(BoxConstraints(minWidth: 120.0));
+
+    // text width based on fontSize 12, plus 24.0 for padding
+    var textWidth = renderParagraph.getMinIntrinsicWidth(12).ceilToDouble() + 24.0;
+
+    // button width is min 120.0 and max 240.0
+    _width = textWidth > 120.0 && textWidth < 240.0 ? textWidth :
+        textWidth >= 240.0 ? 240.0 : 120.0;
 
     _textOpacityAnimation = Tween<double>(begin: 1.0, end: 0.0).animate(
       CurvedAnimation(

--- a/lib/src/widgets/animated_button.dart
+++ b/lib/src/widgets/animated_button.dart
@@ -36,7 +36,6 @@ class _AnimatedButtonState extends State<AnimatedButton>
   var _hover = false;
   var _width = 120.0;
 
-  String _oldText;
   Color _color;
   Color _loadingColor;
 
@@ -56,6 +55,7 @@ class _AnimatedButtonState extends State<AnimatedButton>
     );
 
     // _colorAnimation
+    // _width, _sizeAnimation
 
     _buttonOpacityAnimation =
         Tween<double>(begin: 1.0, end: 0.0).animate(CurvedAnimation(
@@ -81,6 +81,7 @@ class _AnimatedButtonState extends State<AnimatedButton>
   @override
   void didChangeDependencies() {
     _updateColorAnimation();
+    _updateWidth();
     super.didChangeDependencies();
   }
 
@@ -110,6 +111,10 @@ class _AnimatedButtonState extends State<AnimatedButton>
         oldWidget.loadingColor != widget.loadingColor) {
       _updateColorAnimation();
     }
+
+    if (oldWidget.text != widget.text) {
+      _updateWidth();
+    }
   }
 
   @override
@@ -128,7 +133,7 @@ class _AnimatedButtonState extends State<AnimatedButton>
   }
 
   /// sets width and size animation
-  void _updateWidth(BuildContext context) {
+  void _updateWidth() {
     final theme = Theme.of(context);
     final fontSize = theme.textTheme.button.fontSize;
 
@@ -175,11 +180,6 @@ class _AnimatedButtonState extends State<AnimatedButton>
 
   Widget _buildButton(ThemeData theme) {
     final buttonTheme = theme.floatingActionButtonTheme;
-
-    if (widget.text != _oldText) {
-      _updateWidth(context);
-      _oldText = widget.text;
-    }
 
     return FadeTransition(
       opacity: _buttonOpacityAnimation,

--- a/lib/src/widgets/animated_button.dart
+++ b/lib/src/widgets/animated_button.dart
@@ -34,8 +34,9 @@ class _AnimatedButtonState extends State<AnimatedButton>
   Animation<Color> _colorAnimation;
   var _isLoading = false;
   var _hover = false;
-  var _width = -1.0;
+  var _width = 120.0;
 
+  String _oldText;
   Color _color;
   Color _loadingColor;
 
@@ -126,8 +127,8 @@ class _AnimatedButtonState extends State<AnimatedButton>
     }
   }
 
-  // initializes width and size animation
-  void _initWidth(BuildContext context) {
+  /// sets width and size animation
+  void _updateWidth(BuildContext context) {
     final theme = Theme.of(context);
     final fontSize = theme.textTheme.button.fontSize;
 
@@ -146,12 +147,14 @@ class _AnimatedButtonState extends State<AnimatedButton>
 
     renderParagraph.layout(BoxConstraints(minWidth: 120.0));
 
-    // text width based on fontSize, plus 24.0 for padding
-    var textWidth = renderParagraph.getMinIntrinsicWidth(fontSize).ceilToDouble() + 24.0;
+    // text width based on fontSize, plus 64.0 for padding
+    var textWidth =
+        renderParagraph.getMinIntrinsicWidth(fontSize).ceilToDouble() + 64.0;
 
     // button width is min 120.0 and max 240.0
-    _width = textWidth > 120.0 && textWidth < 240.0 ? textWidth :
-      textWidth >= 240.0 ? 240.0 : 120.0;
+    _width = textWidth > 120.0 && textWidth < 240.0
+        ? textWidth
+        : textWidth >= 240.0 ? 240.0 : 120.0;
 
     _sizeAnimation = Tween<double>(begin: 1.0, end: _height / _width)
         .animate(CurvedAnimation(
@@ -173,8 +176,9 @@ class _AnimatedButtonState extends State<AnimatedButton>
   Widget _buildButton(ThemeData theme) {
     final buttonTheme = theme.floatingActionButtonTheme;
 
-    if (_width < 0) {
-      _initWidth(context);
+    if (widget.text != _oldText) {
+      _updateWidth(context);
+      _oldText = widget.text;
     }
 
     return FadeTransition(


### PR DESCRIPTION
This resolves #16. It adjusts animated button width if needed, for a min of 120 and max of 240.

![Screen Shot 2019-11-27 at 2 48 31 PM](https://user-images.githubusercontent.com/55109813/69759158-0300c400-1127-11ea-8de7-ca7833df48d0.png)
