### PR TITLE
fix: Fix flushbar dependent address

### DIFF
--- a/example/lib/custom_route.dart
+++ b/example/lib/custom_route.dart
@@ -18,10 +18,6 @@ class FadePageRoute<T> extends MaterialPageRoute<T> {
     Animation<double> secondaryAnimation,
     Widget child,
   ) {
-    if (settings.isInitialRoute) {
-      return child;
-    }
-
     return FadeTransition(
       opacity: animation,
       child: child,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,9 @@ dependencies:
   font_awesome_flutter: ^8.5.0
   provider: ^4.0.2
   transformer_page_view: ^0.1.6
-  flushbar: ^1.9.1
+  flushbar:
+    git:
+      url: https://github.com/AndreHaueisen/flushbar.git
   # flutter_test from sdk depends on quiver 2.0.5
   quiver: ^2.0.5
 


### PR DESCRIPTION
After flutter update, flushbar cannot run on beat branch or master branch.
So I changed its dependency address and now it points to the git repository.