### PR TITLE
Added an optional cancel button and made forget password & signup buttons be optional

### DIFF
--- a/lib/src/providers/login_messages.dart
+++ b/lib/src/providers/login_messages.dart
@@ -8,6 +8,7 @@ class LoginMessages with ChangeNotifier {
     this.forgotPasswordButton: defaultForgotPasswordButton,
     this.loginButton: defaultLoginButton,
     this.signupButton: defaultSignupButton,
+    this.cancelButton: defaultCancelButton,
     this.recoverPasswordButton: defaultRecoverPasswordButton,
     this.recoverPasswordIntro: defaultRecoverPasswordIntro,
     this.recoverPasswordDescription: defaultRecoverPasswordDescription,
@@ -22,6 +23,7 @@ class LoginMessages with ChangeNotifier {
   static const defaultForgotPasswordButton = 'Forgot Password?';
   static const defaultLoginButton = 'LOGIN';
   static const defaultSignupButton = 'SIGNUP';
+  static const defaultCancelButton = null;
   static const defaultRecoverPasswordButton = 'RECOVER';
   static const defaultRecoverPasswordIntro = 'Reset your password here';
   static const defaultRecoverPasswordDescription =
@@ -47,6 +49,9 @@ class LoginMessages with ChangeNotifier {
 
   /// Signup button's label
   final String signupButton;
+
+  /// Optional cancel button's label
+  final String cancelButton;
 
   /// Recover password button's label
   final String recoverPasswordButton;


### PR DESCRIPTION
In my application, you can use it either as an anonymous user or as a logged in user. If the user brings up the login panel and then changes their mind, the external back button works to cancel the login process, but  I wanted to make it more obvious so I added an optional "Cancel" button.

I also made the "Forget password" and "Sign up" buttons optional as they aren't applicable for my app. If given null labels, they will no longer be shown.

Feel free to incorporate my changes into the mainline (or ignore them if you don't want them  ;-)).