### PR TITLE
"autocorrect" should be false for email fields

### DIFF
--- a/lib/src/widgets/animated_text_form_field.dart
+++ b/lib/src/widgets/animated_text_form_field.dart
@@ -43,6 +43,7 @@ class AnimatedTextFormField extends StatefulWidget {
     this.validator,
     this.onFieldSubmitted,
     this.onSaved,
+    this.autocorrect = true,
   })  : assert((inertiaController == null && inertiaDirection == null) ||
             (inertiaController != null && inertiaDirection != null)),
         super(key: key);
@@ -52,6 +53,7 @@ class AnimatedTextFormField extends StatefulWidget {
   final AnimationController inertiaController;
   final double width;
   final bool enabled;
+  final bool autocorrect;
   final String labelText;
   final Widget prefixIcon;
   final Widget suffixIcon;
@@ -214,6 +216,7 @@ class _AnimatedTextFormFieldState extends State<AnimatedTextFormField> {
       onSaved: widget.onSaved,
       validator: widget.validator,
       enabled: widget.enabled,
+      autocorrect: widget.autocorrect,
     );
 
     if (widget.loadingController != null) {
@@ -298,6 +301,7 @@ class _AnimatedPasswordTextFormFieldState
       inertiaController: widget.inertiaController,
       width: widget.animatedWidth,
       enabled: widget.enabled,
+      autocorrect: false,
       labelText: widget.labelText,
       prefixIcon: Icon(FontAwesomeIcons.lock, size: 20),
       suffixIcon: GestureDetector(

--- a/lib/src/widgets/auth_card.dart
+++ b/lib/src/widgets/auth_card.dart
@@ -1,23 +1,24 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:provider/provider.dart';
 import 'package:transformer_page_view/transformer_page_view.dart';
+
 import '../constants.dart';
+import '../dart_helper.dart';
+import '../matrix.dart';
+import '../models/login_data.dart';
+import '../paddings.dart';
+import '../providers/auth.dart';
+import '../providers/login_messages.dart';
+import '../widget_helper.dart';
 import 'animated_button.dart';
 import 'animated_text.dart';
+import 'animated_text_form_field.dart';
 import 'custom_page_transformer.dart';
 import 'expandable_container.dart';
 import 'fade_in.dart';
-import 'animated_text_form_field.dart';
-import '../providers/auth.dart';
-import '../providers/login_messages.dart';
-import '../models/login_data.dart';
-import '../dart_helper.dart';
-import '../matrix.dart';
-import '../paddings.dart';
-import '../widget_helper.dart';
 
 class AuthCard extends StatefulWidget {
   AuthCard({
@@ -508,6 +509,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
       labelText: messages.usernameHint,
       prefixIcon: Icon(FontAwesomeIcons.solidUserCircle),
       keyboardType: TextInputType.emailAddress,
+      autocorrect: false,
       textInputAction: TextInputAction.next,
       onFieldSubmitted: (value) {
         FocusScope.of(context).requestFocus(_passwordFocusNode);
@@ -762,6 +764,7 @@ class _RecoverCardState extends State<_RecoverCard>
       labelText: messages.usernameHint,
       prefixIcon: Icon(FontAwesomeIcons.solidUserCircle),
       keyboardType: TextInputType.emailAddress,
+      autocorrect: false,
       textInputAction: TextInputAction.done,
       onFieldSubmitted: (value) => _submit(),
       validator: widget.emailValidator,


### PR DESCRIPTION
When I enter an email the autocorrection automatically changes it to something else on iOS.

![Screenshot 2020-05-10 at 10 52 42](https://user-images.githubusercontent.com/17218461/81495282-86fed080-92af-11ea-8590-046016e53fc6.png)
![Screenshot 2020-05-10 at 10 52 53](https://user-images.githubusercontent.com/17218461/81495281-86663a00-92af-11ea-90fc-4dfa9f21c0fa.png)

This can be fixed by setting "autocorrect" to false, which is done in this pull request.