### PR TITLE
Added Custom LoginProvider Buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ titleTag |   `String`     | <sub>`Hero` tag for title text. Need to specify `Log
 showDebugButtons |   `bool`     | <sub>Display the debug buttons to quickly forward/reverse login animations. In release mode, this will be overrided to `false` regardless of the value passed in</sub>
 hideForgotPasswordButton |   `bool`     | <sub>Hides the Forgot Password button if set to true</sub>
 hideSignUpButton |   `bool`     | <sub>Hides the SignUp button if set to true</sub>
+loginProviders |   <sub>`List<LoginProvider>`</sub>    | <sub>Creates either `button` or `icon` for Authenication Providers (e.g. Facebook, Google etc</sub>
 
 
 
@@ -63,6 +64,7 @@ confirmPasswordError | `String` | The error message to show when the confirm pas
 recoverPasswordSuccess | `String` | The success message to show after submitting recover password
 flushbarTitleError | `String` | The Flushbar title on errors
 flushbarTitleSuccess | `String` | The Flushbar title on sucesses
+providersText | `String` | Text for LoginProviders - defaulted to `or login with`
 
 ### LoginTheme
 
@@ -83,6 +85,15 @@ afterHeroFontSize | `double` | Defines the font size of the title in the screen 
 pageColorLight | `Color` | The optional light background color of login screen; if provided, used for light gradient instead of primaryColor
 pageColorDark | `Color` | The optional dark background color of login screen; if provided, used for dark gradient instead of primaryColor
 
+### LoginProvider
+
+Property |   Type     | Desciption
+-------- |------------| ---------------
+button | `Widget` | Used for Buttons for [LoginProvider] - see example uses [SignInButton] package
+icon | `IconData` | Icon that is used for a button for [LoginProvider]
+callback | `ProviderAuthCallback` | To be used as a callback if [LoginProvider] is only using [icon]
+
+*NOTE:* Both [button] and [icon] can be added to [LoginProvider], but [button] will take preference over [icon]
 
 ## Examples
 
@@ -153,6 +164,8 @@ class LoginScreen extends StatelessWidget {
 
 ```dart
 import 'package:flutter/material.dart';
+import 'package:flutter_signin_button/flutter_signin_button.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:flutter_login/flutter_login.dart';
 import 'dashboard_screen.dart';
 
@@ -191,26 +204,28 @@ class LoginScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return FlutterLogin(
       title: 'ECORP',
-      logo: 'assets/images/ecorp-lightblue.png',
+      logo: 'assets/images/ecorp.png',
       onLogin: _authUser,
       onSignup: _authUser,
       
         loginProviders: <LoginProvider>[
+          LoginProvider(
+          button: SignInButton(
+                Buttons.FacebookNew,
+                onPressed: () {
+                  print('start facebook sign in');
+                  await Future.delayed(loginTime);
+                  print('stop facebook sign in');              
+                  return null;
+                },
+              ),
+          ),
           LoginProvider(
             icon: FontAwesomeIcons.google,
             callback: () async {
               print('start google sign in');
               await Future.delayed(loginTime);
               print('stop google sign in');              
-              return null;
-            },
-          ),
-          LoginProvider(
-            icon: FontAwesomeIcons.facebookF,
-            callback: () async {            
-              print('start facebook sign in');
-              await Future.delayed(loginTime);
-              print('stop facebook sign in');              
               return null;
             },
           ),
@@ -244,7 +259,7 @@ class LoginScreen extends StatelessWidget {
 }
 ```
 
-<img src="https://github.com/xnio94/flutter_login/raw/master/demo/sign_in_providers.png" width="300">
+<img src="https://i.ibb.co/smvy4bS/Screenshot-1617591971.png" width="300">
 
 
 

--- a/example/lib/login_screen.dart
+++ b/example/lib/login_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/scheduler.dart' show timeDilation;
 import 'package:flutter/material.dart';
 import 'package:flutter_login/flutter_login.dart';
+import 'package:flutter_signin_button/flutter_signin_button.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'constants.dart';
 import 'custom_route.dart';
 import 'dashboard_screen.dart';
@@ -39,6 +41,46 @@ class LoginScreen extends StatelessWidget {
       logo: 'assets/images/ecorp.png',
       logoTag: Constants.logoTag,
       titleTag: Constants.titleTag,
+      loginProviders: [
+          LoginProvider(
+          button: SignInButton(
+                Buttons.FacebookNew,
+                onPressed: () async {
+                  print('start facebook sign in');
+                  await Future.delayed(loginTime);
+                  print('stop facebook sign in');              
+                  return '';
+                },
+              ),
+          ),
+          LoginProvider(
+            icon: FontAwesomeIcons.google,
+            callback: () async {
+              print('start google sign in');
+              await Future.delayed(loginTime);
+              print('stop google sign in');              
+              return '';
+            },
+          ),
+          LoginProvider(
+            icon: FontAwesomeIcons.linkedinIn,
+            callback: () async {         
+              print('start linkdin sign in');
+              await Future.delayed(loginTime);         
+              print('stop linkdin sign in');              
+              return '';
+            },
+          ),
+          LoginProvider(
+            icon: FontAwesomeIcons.githubAlt,
+            callback: () async {
+              print('start github sign in');
+              await Future.delayed(loginTime);
+              print('stop github sign in');              
+              return '';
+            },
+          ),
+      ],
       // loginAfterSignUp: false,
       // hideForgotPasswordButton: true,
       // hideSignUpButton: true,
@@ -169,7 +211,7 @@ class LoginScreen extends StatelessWidget {
         return _recoverPassword(name);
         // Show new password dialog
       },
-      showDebugButtons: true,
+      // showDebugButtons: true,
     );
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -82,7 +82,14 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.0"
+    version: "2.0.0-nullsafety.0"
+  flutter_signin_button:
+    dependency: "direct main"
+    description:
+      name: flutter_signin_button
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -162,7 +169,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -16,6 +16,8 @@ dependencies:
   intl: ^0.17.0
   # dummy package to test https://github.com/NearHuscarl/flutter_login/issues/35
   provider: ^5.0.0
+  # Package for Provider Buttons PR
+  flutter_signin_button: ^2.0.0
 
 dev_dependencies:
   flutter_test:

--- a/lib/flutter_login.dart
+++ b/lib/flutter_login.dart
@@ -25,10 +25,15 @@ export 'src/providers/login_theme.dart';
 import 'src/constants.dart';
 
 class LoginProvider {
-  final IconData icon;
-  final ProviderAuthCallback callback;
+  final IconData? icon;
+  final Widget? button;
+  final ProviderAuthCallback? callback;
 
-  LoginProvider({required this.icon, required this.callback});
+  LoginProvider({
+    this.button,
+    this.icon, 
+    this.callback,
+    });
 }
 
 class _AnimationTimeDilationDropdown extends StatelessWidget {

--- a/lib/src/providers/login_messages.dart
+++ b/lib/src/providers/login_messages.dart
@@ -17,6 +17,7 @@ class LoginMessages with ChangeNotifier {
     this.flushbarTitleError = defaultflushbarTitleError,
     this.flushbarTitleSuccess = defaultflushbarTitleSuccess,
     this.signUpSuccess = defaultSignUpSuccess,
+    this.providersText = defaultProvidersText,
   });
 
   static const defaultUsernameHint = 'Email';
@@ -35,6 +36,7 @@ class LoginMessages with ChangeNotifier {
   static const defaultflushbarTitleSuccess = 'Success';
   static const defaultflushbarTitleError = 'Error';
   static const defaultSignUpSuccess = 'An activation link has been sent';
+  static const defaultProvidersText = 'or login with';
 
   /// Hint text of the user name [TextField]
   final String usernameHint;
@@ -82,4 +84,7 @@ class LoginMessages with ChangeNotifier {
 
   /// The success message to show after signing up
   final String signUpSuccess;
+
+  // The Text above the providers buttons/icons
+  final String providersText;
 }

--- a/lib/src/widgets/auth_card.dart
+++ b/lib/src/widgets/auth_card.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
+import '../../flutter_login.dart';
 import 'animated_button.dart';
 import 'animated_icon.dart';
 import 'animated_text.dart';
@@ -699,25 +700,91 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
     );
   }
 
-  Widget _buildProvidersLogInButton(ThemeData theme, LoginMessages messages,
-      Auth auth, LoginTheme loginTheme) {
+  Widget _buildProvidersLogInButton(ThemeData theme, LoginMessages messages, Auth auth, LoginTheme loginTheme) {
+    // ignore: omit_local_variable_types
+    List<LoginProvider> buttonProvidersList = [];
+    // ignore: omit_local_variable_types
+    List<LoginProvider> iconProvidersList = [];
+    auth.loginProviders?.forEach((LoginProvider loginProvider) {
+      if(loginProvider.button != null){
+        buttonProvidersList.add( 
+          LoginProvider(
+            icon: loginProvider.icon,
+            button: loginProvider.button,
+            callback: loginProvider.callback,
+          )
+        );
+      } else if (loginProvider.icon != null){
+        iconProvidersList.add( 
+          LoginProvider(
+            icon: loginProvider.icon,
+            button: loginProvider.button,
+            callback: loginProvider.callback,
+          )
+        );
+      }
+    });
+    if(buttonProvidersList.isNotEmpty){
+      return Column(
+        children: [
+          _buildButtonColumn(theme, messages, buttonProvidersList, loginTheme),
+          iconProvidersList.isNotEmpty ? Row(
+            children: <Widget>[
+                Expanded(
+                    child: Divider()
+                ),       
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Text('OR'),
+                ),        
+                Expanded(
+                    child: Divider()
+                ),
+              ]
+          ) : Container(),
+          _buildIconRow(theme, messages, iconProvidersList, loginTheme),
+        ],
+      );
+    } else if (iconProvidersList.isNotEmpty){
+      return _buildIconRow(theme, messages, iconProvidersList, loginTheme);
+    }
+    return Container();
+  }
+
+  Widget _buildButtonColumn(ThemeData theme, LoginMessages messages, List<LoginProvider> buttonProvidersList, LoginTheme loginTheme){
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: buttonProvidersList.map((loginProvider) {
+        return Padding(
+          padding: loginTheme.providerButtonPadding ??
+              const EdgeInsets.symmetric(horizontal: 6.0, vertical: 8.0),
+          child: ScaleTransition(
+            scale: _buttonScaleAnimation,
+            child: loginProvider.button,
+          ),
+        );
+      }).toList(),
+    );
+  }
+
+  Widget _buildIconRow(ThemeData theme, LoginMessages messages, List<LoginProvider> iconProvidersList, LoginTheme loginTheme){
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
-      children: auth.loginProviders!.map((loginProvider) {
-        var index = auth.loginProviders!.indexOf(loginProvider);
+      children: iconProvidersList.map((loginProvider) {
+        var index = iconProvidersList.indexOf(loginProvider);
         return Padding(
           padding: loginTheme.providerButtonPadding ??
               const EdgeInsets.symmetric(horizontal: 6.0, vertical: 8.0),
           child: ScaleTransition(
             scale: _buttonScaleAnimation,
             child: AnimatedIconButton(
-              icon: loginProvider.icon,
+              icon: loginProvider.icon!,
               controller: _providerControllerList[index],
               tooltip: '',
               onPressed: () => _loginProviderSubmit(
                 control: _providerControllerList[index],
                 callback: () {
-                  return loginProvider.callback();
+                  return loginProvider.callback!();
                 },
               ),
             ),
@@ -791,6 +858,20 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
                     : SizedBox.fromSize(
                         size: Size.fromHeight(10),
                       ),
+                 auth.loginProviders!.isNotEmpty ? Row(
+                  children: <Widget>[
+                      Expanded(
+                          child: Divider()
+                      ),       
+                      Padding(
+                        padding: const EdgeInsets.all(8.0),
+                        child: Text(messages.providersText),
+                      ),        
+                      Expanded(
+                          child: Divider()
+                      ),
+                    ]
+                ) : Container(),
                 _buildProvidersLogInButton(theme, messages, auth, loginTheme),
               ],
             ),


### PR DESCRIPTION
- Added LoginProviders to have Buttons
- Continued Null-Safety
- Updated example
- Updated README.md - to include `LoginProvider` class and other updates.

I have removed the required fields of `icon` and `callback` as buttons have required `onPressed`. 

`LoginProvider` class can have both button and icons - but will take button as preference. If there are `LoginProviders` that have buttons, and others have icons only - it creates a divider as per image.

![Screenshot_1617591971](https://user-images.githubusercontent.com/62976701/113533197-6f47dd80-9621-11eb-98a5-efb1a6c1018e.png)

