### PR TITLE
Export login_user_type model

### DIFF
--- a/example/lib/widgets/fade_in.dart
+++ b/example/lib/widgets/fade_in.dart
@@ -16,7 +16,7 @@ class FadeIn extends StatefulWidget {
     this.duration,
     this.curve = Curves.easeOut,
     required this.child,
-  })   : assert(controller == null && duration != null ||
+  })  : assert(controller == null && duration != null ||
             controller != null && duration == null),
         assert(offset > 0),
         super(key: key);

--- a/lib/flutter_login.dart
+++ b/lib/flutter_login.dart
@@ -21,6 +21,7 @@ import 'src/widgets/fade_in.dart';
 import 'src/widgets/hero_text.dart';
 import 'src/widgets/gradient_box.dart';
 export 'src/models/login_data.dart';
+export 'src/models/login_user_type.dart';
 export 'src/providers/login_messages.dart';
 export 'src/providers/login_theme.dart';
 import 'src/constants.dart';

--- a/lib/src/widgets/fade_in.dart
+++ b/lib/src/widgets/fade_in.dart
@@ -16,7 +16,7 @@ class FadeIn extends StatefulWidget {
     this.duration,
     this.curve = Curves.easeOut,
     required this.child,
-  })   : assert(controller == null && duration != null ||
+  })  : assert(controller == null && duration != null ||
             controller != null && duration == null),
         assert(offset > 0),
         super(key: key);


### PR DESCRIPTION
The model defining the enum `LoginUserType` wasn't exported, so it couldn't be used outside of the library. This fixes it.