### PR TITLE
Add a bar with a title/description above providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ titleTag |   `String`     | <sub>`Hero` tag for title text. Need to specify `Log
 showDebugButtons |   `bool`     | <sub>Display the debug buttons to quickly forward/reverse login animations. In release mode, this will be overridden to `false` regardless of the value passed in</sub>
 hideForgotPasswordButton |   `bool`     | <sub>Hides the Forgot Password button if set to true</sub>
 hideSignUpButton |   `bool`     | <sub>Hides the SignUp button if set to true</sub>
+hideProvidersTitle |   `bool`     | <sub>Hides the title above login providers if set to true. In case the providers List is empty this is uneffective, as the title is hidden anyways. The default is `false`</sub>
+
 
 
 
@@ -67,6 +69,7 @@ confirmPasswordError | `String` | The error message to show when the confirm pas
 recoverPasswordSuccess | `String` | The success message to show after submitting recover password
 flushbarTitleError | `String` | The Flushbar title on errors
 flushbarTitleSuccess | `String` | The Flushbar title on successes
+providersTitle | `String` | A string shown above the login Providers, defaults to `or login with`
 
 ### LoginTheme
 

--- a/example/lib/login_screen.dart
+++ b/example/lib/login_screen.dart
@@ -39,6 +39,8 @@ class LoginScreen extends StatelessWidget {
       logo: 'assets/images/ecorp.png',
       logoTag: Constants.logoTag,
       titleTag: Constants.titleTag,
+      loginProviders: [],
+      // hideProvidersTitle: true,
       // loginAfterSignUp: false,
       // hideForgotPasswordButton: true,
       // hideSignUpButton: true,
@@ -57,6 +59,7 @@ class LoginScreen extends StatelessWidget {
       //   recoverPasswordSuccess: 'Password rescued successfully',
       //   flushbarTitleError: 'Oh no!',
       //   flushbarTitleSuccess: 'Succes!',
+      //   providersTitle: 'login with'
       // ),
       // theme: LoginTheme(
       //   primaryColor: Colors.teal,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -162,7 +162,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -197,7 +197,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:

--- a/lib/flutter_login.dart
+++ b/lib/flutter_login.dart
@@ -241,7 +241,8 @@ class FlutterLogin extends StatefulWidget {
       this.hideForgotPasswordButton = false,
       this.hideSignUpButton = false,
       this.loginAfterSignUp = true,
-      this.footer})
+      this.footer,
+      this.hideProvidersTitle = false})
       : super(key: key);
 
   /// Called when the user hit the submit button when in sign up mode
@@ -313,6 +314,9 @@ class FlutterLogin extends StatefulWidget {
 
   /// Optional footer text for example a copyright notice
   final String? footer;
+
+  /// Hide the title above the login providers. If no providers are set this is uneffective
+  final bool hideProvidersTitle;
 
   static final FormFieldValidator<String> defaultEmailValidator = (value) {
     if (value!.isEmpty || !Regex.email.hasMatch(value)) {
@@ -647,6 +651,7 @@ class _FlutterLoginState extends State<FlutterLogin>
                         hideForgotPasswordButton:
                             widget.hideForgotPasswordButton,
                         loginAfterSignUp: widget.loginAfterSignUp,
+                        hideProvidersTitle: widget.hideProvidersTitle,
                       ),
                     ),
                     Positioned(

--- a/lib/src/providers/auth.dart
+++ b/lib/src/providers/auth.dart
@@ -16,7 +16,7 @@ typedef RecoverCallback = Future<String?>? Function(String);
 
 class Auth with ChangeNotifier {
   Auth({
-    this.loginProviders,
+    this.loginProviders = const [],
     this.onLogin,
     this.onSignup,
     this.onRecoverPassword,
@@ -30,7 +30,7 @@ class Auth with ChangeNotifier {
   final AuthCallback? onLogin;
   final AuthCallback? onSignup;
   final RecoverCallback? onRecoverPassword;
-  final List<LoginProvider>? loginProviders;
+  final List<LoginProvider> loginProviders;
 
   AuthMode _mode = AuthMode.Login;
 

--- a/lib/src/providers/login_messages.dart
+++ b/lib/src/providers/login_messages.dart
@@ -1,23 +1,23 @@
 import 'package:flutter/material.dart';
 
 class LoginMessages with ChangeNotifier {
-  LoginMessages({
-    this.userHint = defaultUserHint,
-    this.passwordHint = defaultPasswordHint,
-    this.confirmPasswordHint = defaultConfirmPasswordHint,
-    this.forgotPasswordButton = defaultForgotPasswordButton,
-    this.loginButton = defaultLoginButton,
-    this.signupButton = defaultSignupButton,
-    this.recoverPasswordButton = defaultRecoverPasswordButton,
-    this.recoverPasswordIntro = defaultRecoverPasswordIntro,
-    this.recoverPasswordDescription = defaultRecoverPasswordDescription,
-    this.goBackButton = defaultGoBackButton,
-    this.confirmPasswordError = defaultConfirmPasswordError,
-    this.recoverPasswordSuccess = defaultRecoverPasswordSuccess,
-    this.flushbarTitleError = defaultflushbarTitleError,
-    this.flushbarTitleSuccess = defaultflushbarTitleSuccess,
-    this.signUpSuccess = defaultSignUpSuccess,
-  });
+  LoginMessages(
+      {this.userHint = defaultUserHint,
+      this.passwordHint = defaultPasswordHint,
+      this.confirmPasswordHint = defaultConfirmPasswordHint,
+      this.forgotPasswordButton = defaultForgotPasswordButton,
+      this.loginButton = defaultLoginButton,
+      this.signupButton = defaultSignupButton,
+      this.recoverPasswordButton = defaultRecoverPasswordButton,
+      this.recoverPasswordIntro = defaultRecoverPasswordIntro,
+      this.recoverPasswordDescription = defaultRecoverPasswordDescription,
+      this.goBackButton = defaultGoBackButton,
+      this.confirmPasswordError = defaultConfirmPasswordError,
+      this.recoverPasswordSuccess = defaultRecoverPasswordSuccess,
+      this.flushbarTitleError = defaultflushbarTitleError,
+      this.flushbarTitleSuccess = defaultflushbarTitleSuccess,
+      this.signUpSuccess = defaultSignUpSuccess,
+      this.providersTitle = defaultProvidersTitle});
 
   static const defaultUserHint = 'Email';
   static const defaultPasswordHint = 'Password';
@@ -35,6 +35,7 @@ class LoginMessages with ChangeNotifier {
   static const defaultflushbarTitleSuccess = 'Success';
   static const defaultflushbarTitleError = 'Error';
   static const defaultSignUpSuccess = 'An activation link has been sent';
+  static const defaultProvidersTitle = 'or login with';
 
   /// Hint text of the userHint [TextField]
   /// By default is Email
@@ -83,4 +84,7 @@ class LoginMessages with ChangeNotifier {
 
   /// The success message to show after signing up
   final String signUpSuccess;
+
+  /// The string shown above the Providers buttons
+  final String providersTitle;
 }

--- a/lib/src/widgets/auth_card.dart
+++ b/lib/src/widgets/auth_card.dart
@@ -25,19 +25,20 @@ import '../widget_helper.dart';
 
 // TODO Improvement: Keep just this in auth_card.dart
 class AuthCard extends StatefulWidget {
-  AuthCard({
-    Key? key,
-    required this.userType,
-    this.padding = const EdgeInsets.all(0),
-    this.loadingController,
-    this.userValidator,
-    this.passwordValidator,
-    this.onSubmit,
-    this.onSubmitCompleted,
-    this.hideForgotPasswordButton = false,
-    this.hideSignUpButton = false,
-    this.loginAfterSignUp = true,
-  }) : super(key: key);
+  AuthCard(
+      {Key? key,
+      required this.userType,
+      this.padding = const EdgeInsets.all(0),
+      this.loadingController,
+      this.userValidator,
+      this.passwordValidator,
+      this.onSubmit,
+      this.onSubmitCompleted,
+      this.hideForgotPasswordButton = false,
+      this.hideSignUpButton = false,
+      this.loginAfterSignUp = true,
+      this.hideProvidersTitle = false})
+      : super(key: key);
 
   final EdgeInsets padding;
   final AnimationController? loadingController;
@@ -49,6 +50,7 @@ class AuthCard extends StatefulWidget {
   final bool hideSignUpButton;
   final bool loginAfterSignUp;
   final LoginUserType userType;
+  final bool hideProvidersTitle;
 
   @override
   AuthCardState createState() => AuthCardState();
@@ -311,6 +313,7 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
                     hideSignUpButton: widget.hideSignUpButton,
                     hideForgotPasswordButton: widget.hideForgotPasswordButton,
                     loginAfterSignUp: widget.loginAfterSignUp,
+                    hideProvidersTitle: widget.hideProvidersTitle,
                   ),
                 )
               : _RecoverCard(
@@ -345,19 +348,20 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
 
 // TODO Improvement: Modularize this in a login_card.dart
 class _LoginCard extends StatefulWidget {
-  _LoginCard({
-    Key? key,
-    this.loadingController,
-    required this.userValidator,
-    required this.passwordValidator,
-    required this.onSwitchRecoveryPassword,
-    required this.userType,
-    this.onSwitchAuth,
-    this.onSubmitCompleted,
-    this.hideForgotPasswordButton = false,
-    this.hideSignUpButton = false,
-    this.loginAfterSignUp = true,
-  }) : super(key: key);
+  _LoginCard(
+      {Key? key,
+      this.loadingController,
+      required this.userValidator,
+      required this.passwordValidator,
+      required this.onSwitchRecoveryPassword,
+      required this.userType,
+      this.onSwitchAuth,
+      this.onSubmitCompleted,
+      this.hideForgotPasswordButton = false,
+      this.hideSignUpButton = false,
+      this.loginAfterSignUp = true,
+      this.hideProvidersTitle = false})
+      : super(key: key);
 
   final AnimationController? loadingController;
   final FormFieldValidator<String>? userValidator;
@@ -368,6 +372,7 @@ class _LoginCard extends StatefulWidget {
   final bool hideForgotPasswordButton;
   final bool hideSignUpButton;
   final bool loginAfterSignUp;
+  final bool hideProvidersTitle;
   final LoginUserType userType;
 
   @override
@@ -434,7 +439,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
       vsync: this,
       duration: Duration(milliseconds: 1000),
     );
-    _providerControllerList = auth.loginProviders!
+    _providerControllerList = auth.loginProviders
         .map(
           (e) => AnimationController(
             vsync: this,
@@ -744,8 +749,8 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
       Auth auth, LoginTheme loginTheme) {
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
-      children: auth.loginProviders!.map((loginProvider) {
-        var index = auth.loginProviders!.indexOf(loginProvider);
+      children: auth.loginProviders.map((loginProvider) {
+        var index = auth.loginProviders.indexOf(loginProvider);
         return Padding(
           padding: loginTheme.providerButtonPadding ??
               const EdgeInsets.symmetric(horizontal: 6.0, vertical: 8.0),
@@ -832,6 +837,16 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
                     : SizedBox.fromSize(
                         size: Size.fromHeight(10),
                       ),
+                auth.loginProviders.isNotEmpty && !widget.hideProvidersTitle
+                    ? Row(children: <Widget>[
+                        Expanded(child: Divider()),
+                        Padding(
+                          padding: const EdgeInsets.all(8.0),
+                          child: Text(messages.providersTitle),
+                        ),
+                        Expanded(child: Divider()),
+                      ])
+                    : Container(),
                 _buildProvidersLogInButton(theme, messages, auth, loginTheme),
               ],
             ),


### PR DESCRIPTION
Inspired by #149, this adds a bar above the provider icons, to make the login page more intuitive for the user.  

<p style="float: right;">
<img src="https://user-images.githubusercontent.com/27235626/120247199-f2c52a00-c272-11eb-8481-3a674d417fe0.png" width="250" />
<img src="https://user-images.githubusercontent.com/27235626/120247203-f658b100-c272-11eb-8928-8b898c1f7287.png" width="250"  />
</p>

By default the bar is shown, this can be changed by setting the property `hideProvidersTitle` to `true`.

I also set the `loginProviders` list as empty by default, rather than `null`, to improve null-safety.