### PR TITLE
Added the switchAuthTextColor property, if provided a different color…

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ afterHeroFontSize | `double` | Defines the font size of the title in the screen 
 pageColorLight | `Color` | The optional light background color of login screen; if provided, used for light gradient instead of primaryColor
 pageColorDark | `Color` | The optional dark background color of login screen; if provided, used for dark gradient instead of primaryColor
 footerBottomPadding | `double` | The footer bottom Padding; defaults to 0 if not provided.
+switchAuthTextColor | `Color` | The optional color for the switch authentication text, if nothing is specified [primaryColor] is used.
 
 ### LoginUserType
 Enum     |   Description |

--- a/lib/src/providers/login_theme.dart
+++ b/lib/src/providers/login_theme.dart
@@ -53,6 +53,7 @@ class LoginTheme with ChangeNotifier {
     this.beforeHeroFontSize = 48.0,
     this.afterHeroFontSize = 15.0,
     this.footerBackgroundColor,
+    this.switchAuthTextColor,
     this.footerTextStyle,
     this.authButtonPadding,
     this.providerButtonPadding,
@@ -110,6 +111,9 @@ class LoginTheme with ChangeNotifier {
 
   /// Color of the footer background
   final Color? footerBackgroundColor;
+
+  /// Color of the switch authentication button
+  final Color? switchAuthTextColor;
 
   /// Text style for footer text
   final TextStyle? footerTextStyle;

--- a/lib/src/widgets/auth_card.dart
+++ b/lib/src/widgets/auth_card.dart
@@ -736,7 +736,9 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
         padding: loginTheme.authButtonPadding ??
             EdgeInsets.symmetric(horizontal: 30.0, vertical: 8.0),
         materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-        textColor: theme.primaryColor,
+        textColor: loginTheme.switchAuthTextColor != null
+            ? loginTheme.switchAuthTextColor!
+            : theme.primaryColor,
         child: AnimatedText(
           text: auth.isSignup ? messages.loginButton : messages.signupButton,
           textRotation: AnimatedTextRotation.down,


### PR DESCRIPTION
… from primaryColor is used for the switch authentication text

This way is possible to set primaryColor to transparent and is possible to specify a different color for the authentication switch text.