### PR TITLE
:fire: Now, input decoration colors depends on primary color.

### DIFF
--- a/lib/flutter_login.dart
+++ b/lib/flutter_login.dart
@@ -536,7 +536,7 @@ class _FlutterLoginState extends State<FlutterLogin>
         contentPadding: inputTheme.contentPadding ??
             const EdgeInsets.symmetric(vertical: 4.0),
         errorStyle: inputTheme.errorStyle ?? TextStyle(color: errorColor),
-        labelStyle: inputTheme.labelStyle,
+        labelStyle: inputTheme.labelStyle ?? TextStyle(color: primaryColor),
         enabledBorder: inputTheme.enabledBorder ??
             inputTheme.border ??
             OutlineInputBorder(

--- a/lib/src/widgets/animated_text_form_field.dart
+++ b/lib/src/widgets/animated_text_form_field.dart
@@ -208,6 +208,7 @@ class _AnimatedTextFormFieldState extends State<AnimatedTextFormField> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     Widget textField = TextFormField(
+      cursorColor: theme.primaryColor,
       controller: widget.controller,
       focusNode: widget.focusNode,
       decoration: _getInputDecoration(theme),


### PR DESCRIPTION
This fix the next bug: https://github.com/NearHuscarl/flutter_login/issues/200

It is also notewhorthy to say the prefix and sufix icons depends on the `ThemeData.colorScheme.primary` color, which can be differente to the `ThemeData.primaryColor`; we should make both to be the same or to make one of them by default.

![image](https://user-images.githubusercontent.com/5034215/125830735-9d86e3a8-94fa-467b-9d23-23beeaf48884.png)

@juliansteenbakker @NearHuscarl 