### PR TITLE
Fix examples in README.md after Signup structure changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ const users = const {
 class LoginScreen extends StatelessWidget {
   Duration get loginTime => Duration(milliseconds: 2250);
 
-  Future<String> _authUser(LoginData data) {
+  Future<String ?> _authUser(LoginData data) {
     print('Name: ${data.name}, Password: ${data.password}');
     return Future.delayed(loginTime).then((_) {
       if (!users.containsKey(data.name)) {
@@ -172,6 +172,13 @@ class LoginScreen extends StatelessWidget {
       if (users[data.name] != data.password) {
         return 'Password does not match';
       }
+      return null;
+    });
+  }
+
+  Future<String ?> _signupUser(SignupData data) {
+    print('Signup Name: ${data.name}, Password: ${data.password}');
+    return Future.delayed(loginTime).then((_) {
       return null;
     });
   }
@@ -192,7 +199,7 @@ class LoginScreen extends StatelessWidget {
       title: 'ECORP',
       logo: AssetImage('assets/images/ecorp-lightblue.png'),
       onLogin: _authUser,
-      onSignup: _authUser,
+      onSignup: _signupUser,
       onSubmitAnimationCompleted: () {
         Navigator.of(context).pushReplacement(MaterialPageRoute(
           builder: (context) => DashboardScreen(),
@@ -223,7 +230,7 @@ const users = const {
 class LoginScreen extends StatelessWidget {
   Duration get loginTime => Duration(milliseconds: 2250);
 
-  Future<String> _authUser(LoginData data) {
+  Future<String ?> _authUser(LoginData data) {
     print('Name: ${data.name}, Password: ${data.password}');
     return Future.delayed(loginTime).then((_) {
       if (!users.containsKey(data.name)) {
@@ -232,6 +239,13 @@ class LoginScreen extends StatelessWidget {
       if (users[data.name] != data.password) {
         return 'Password does not match';
       }
+      return null;
+    });
+  }
+
+  Future<String ?> _signupUser(SignupData data) {
+    print('Signup Name: ${data.name}, Password: ${data.password}');
+    return Future.delayed(loginTime).then((_) {
       return null;
     });
   }
@@ -252,7 +266,7 @@ class LoginScreen extends StatelessWidget {
       title: 'ECORP',
       logo: AssetImage('assets/images/ecorp-lightblue.png'),
       onLogin: _authUser,
-      onSignup: _authUser,
+      onSignup: _signupUser,
       
         loginProviders: <LoginProvider>[
           LoginProvider(


### PR DESCRIPTION
After merge of #221 the interface for the callback for signup is
now different from the login one, so a single test function cannot
be used. Fix the examples in README.md to reflect this to help new
users starting with the plugin.