### PR TITLE
fix: prevent setState() and forward() after dispose()

### DIFF
--- a/lib/flutter_login.dart
+++ b/lib/flutter_login.dart
@@ -379,7 +379,7 @@ class FlutterLogin extends StatefulWidget {
   /// Called when the user hits the resend code button in confirm signup mode
   /// Only when onConfirmSignup is set
   final SignupCallback? onResendCode;
-  
+
   /// Prefilled (ie. saved from previous session) value at startup for username
   /// (Auth class calls username email, therefore we use savedEmail here aswell)
   final String savedEmail;
@@ -442,7 +442,9 @@ class _FlutterLoginState extends State<FlutterLogin>
     );
 
     Future.delayed(const Duration(seconds: 1), () {
-      _loadingController!.forward();
+      if (mounted) {
+        _loadingController!.forward();
+      }
     });
   }
 

--- a/lib/src/widgets/login_card.dart
+++ b/lib/src/widgets/login_card.dart
@@ -191,7 +191,9 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
     // workaround to run after _cardSizeAnimation in parent finished
     // need a cleaner way but currently it works so..
     Future.delayed(const Duration(milliseconds: 270), () {
-      setState(() => _showShadow = false);
+      if (mounted) {
+        setState(() => _showShadow = false);
+      }
     });
 
     await _submitController.reverse();
@@ -199,7 +201,9 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
     if (!DartHelper.isNullOrEmpty(error)) {
       showErrorToast(context, messages.flushbarTitleError, error!);
       Future.delayed(const Duration(milliseconds: 271), () {
-        setState(() => _showShadow = true);
+        if (mounted) {
+          setState(() => _showShadow = true);
+        }
       });
       setState(() => _isSubmitting = false);
       return false;
@@ -260,7 +264,9 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
     // workaround to run after _cardSizeAnimation in parent finished
     // need a cleaner way but currently it works so..
     Future.delayed(const Duration(milliseconds: 270), () {
-      setState(() => _showShadow = false);
+      if (mounted) {
+        setState(() => _showShadow = false);
+      }
     });
 
     await animationController.reverse();
@@ -270,7 +276,9 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
     if (!DartHelper.isNullOrEmpty(error)) {
       showErrorToast(context, messages.flushbarTitleError, error!);
       Future.delayed(const Duration(milliseconds: 271), () {
-        setState(() => _showShadow = true);
+        if (mounted) {
+          setState(() => _showShadow = true);
+        }
       });
       return false;
     }


### PR DESCRIPTION
Related to #152.

Calling setState() after a delay risks running it after the the widget has already been disposed. I added conditions so that calls to setState() will only run if the widget is still "mounted" as suggested by the following error message:

`[VERBOSE-2:ui_dart_state.cc(199)] Unhandled Exception: setState() called after dispose(): _LoginCardState#2564a(lifecycle state: defunct, not mounted, tickers: tracking 0 tickers)
This error happens if you call setState() on a State object for a widget that no longer appears in the widget tree (e.g., whose parent widget no longer includes the widget in its build). This error can occur when code calls setState() from a timer or an animation callback.
The preferred solution is to cancel the timer or stop listening to the animation in the dispose() callback. Another solution is to check the "mounted" property of this object before calling setState() to ensure the object is still in the tree.
This error might indicate a memory leak if setState() is being called because another object is retaining a reference to this State object after it has been removed from the tree. To avoid memory leaks, consider breaking the reference to this object during dispose().
#0      State.setState.<anonymous closure> (packa<…>`