### PR TITLE
Disable user/pass input forms when submitted and auth is being done

### DIFF
--- a/lib/flutter_login.dart
+++ b/lib/flutter_login.dart
@@ -640,7 +640,12 @@ class _FlutterLoginState extends State<FlutterLogin>
               borderSide: BorderSide(color: errorColor, width: 1.5),
               borderRadius: roundBorderRadius,
             ),
-        disabledBorder: inputTheme.disabledBorder ?? inputTheme.border,
+        disabledBorder: inputTheme.disabledBorder ??
+            inputTheme.border ??
+            OutlineInputBorder(
+              borderSide: BorderSide(color: Colors.transparent),
+              borderRadius: roundBorderRadius,
+            ),
       ),
       floatingActionButtonTheme: theme.floatingActionButtonTheme.copyWith(
         backgroundColor: buttonTheme.backgroundColor ?? primaryColor,

--- a/lib/flutter_login.dart
+++ b/lib/flutter_login.dart
@@ -379,7 +379,7 @@ class FlutterLogin extends StatefulWidget {
   /// Called when the user hits the resend code button in confirm signup mode
   /// Only when onConfirmSignup is set
   final SignupCallback? onResendCode;
-  
+
   /// Prefilled (ie. saved from previous session) value at startup for username
   /// (Auth class calls username email, therefore we use savedEmail here aswell)
   final String savedEmail;

--- a/lib/src/widgets/login_card.dart
+++ b/lib/src/widgets/login_card.dart
@@ -298,7 +298,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
       loadingController: _loadingController,
       interval: _nameTextFieldLoadingAnimationInterval,
       labelText: messages.userHint,
-      autofillHints: [TextFieldUtils.getAutofillHints(widget.userType)],
+      autofillHints: _isSubmitting ? null : [TextFieldUtils.getAutofillHints(widget.userType)],
       prefixIcon: Icon(FontAwesomeIcons.solidUserCircle),
       keyboardType: TextFieldUtils.getKeyboardType(widget.userType),
       textInputAction: TextInputAction.next,
@@ -307,6 +307,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
       },
       validator: widget.userValidator,
       onSaved: (value) => auth.email = value!,
+      enabled: !_isSubmitting,
     );
   }
 
@@ -316,8 +317,8 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
       loadingController: _loadingController,
       interval: _passTextFieldLoadingAnimationInterval,
       labelText: messages.passwordHint,
-      autofillHints:
-          auth.isLogin ? [AutofillHints.password] : [AutofillHints.newPassword],
+      autofillHints: _isSubmitting ? null :
+          (auth.isLogin ? [AutofillHints.password] : [AutofillHints.newPassword]),
       controller: _passController,
       textInputAction:
           auth.isLogin ? TextInputAction.done : TextInputAction.next,
@@ -332,6 +333,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
       },
       validator: widget.passwordValidator,
       onSaved: (value) => auth.password = value!,
+      enabled: !_isSubmitting,
     );
   }
 

--- a/lib/src/widgets/login_card.dart
+++ b/lib/src/widgets/login_card.dart
@@ -298,7 +298,9 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
       loadingController: _loadingController,
       interval: _nameTextFieldLoadingAnimationInterval,
       labelText: messages.userHint,
-      autofillHints: _isSubmitting ? null : [TextFieldUtils.getAutofillHints(widget.userType)],
+      autofillHints: _isSubmitting
+          ? null
+          : [TextFieldUtils.getAutofillHints(widget.userType)],
       prefixIcon: Icon(FontAwesomeIcons.solidUserCircle),
       keyboardType: TextFieldUtils.getKeyboardType(widget.userType),
       textInputAction: TextInputAction.next,
@@ -317,8 +319,11 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
       loadingController: _loadingController,
       interval: _passTextFieldLoadingAnimationInterval,
       labelText: messages.passwordHint,
-      autofillHints: _isSubmitting ? null :
-          (auth.isLogin ? [AutofillHints.password] : [AutofillHints.newPassword]),
+      autofillHints: _isSubmitting
+          ? null
+          : (auth.isLogin
+              ? [AutofillHints.password]
+              : [AutofillHints.newPassword]),
       controller: _passController,
       textInputAction:
           auth.isLogin ? TextInputAction.done : TextInputAction.next,


### PR DESCRIPTION
While the application is waiting to complete the authentication with this MR the user/password fields will be disabled, so user cannot change stuff in the meantime and to have a more consistent interface look.

This solves #217. 

Could be in case extended in a similar fashion to signup if deemed interesting.

Tech notes on mods: when disabled `autoFillHints` must be removed or an exeception happens. We have to override also the `disabledBorder` so we have the same look and feel (otherwise the default non rounded border would be used when it is disabled)