### PR TITLE
Fixed signup confirmation flow and improvement of code readability #280

### DIFF
--- a/lib/src/widgets/cards/auth_card_builder.dart
+++ b/lib/src/widgets/cards/auth_card_builder.dart
@@ -339,6 +339,8 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
                 widget.onSubmitCompleted!();
               });
             },
+            requireSignUpConfirmation: auth.onConfirmSignup != null,
+            onSwitchConfirmSignup: () => _changeCard(_confirmSignup),
             hideSignUpButton: widget.hideSignUpButton,
             hideForgotPasswordButton: widget.hideForgotPasswordButton,
             loginAfterSignUp: widget.loginAfterSignUp,
@@ -402,12 +404,18 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
           theme: Theme.of(context),
           child: _ConfirmSignupCard(
             key: _confirmSignUpCardKey,
-            onBack: () => _changeCard(_loginPageIndex),
+            onBack: () => auth.additionalSignupData == null
+                ? _changeCard(_loginPageIndex)
+                : _changeCard(_additionalSignUpIndex),
             loadingController: formController,
             onSubmitCompleted: () {
-              _forwardChangeRouteAnimation(_confirmSignUpCardKey).then((_) {
-                widget.onSubmitCompleted!();
-              });
+              if (widget.loginAfterSignUp) {
+                _forwardChangeRouteAnimation(_confirmSignUpCardKey).then((_) {
+                  widget.onSubmitCompleted!();
+                });
+              } else {
+                _changeCard(_loginPageIndex);
+              }
             },
             loginAfterSignUp: widget.loginAfterSignUp,
           ),

--- a/lib/src/widgets/cards/login_card.dart
+++ b/lib/src/widgets/cards/login_card.dart
@@ -10,7 +10,8 @@ class _LoginCard extends StatefulWidget {
     required this.onSwitchSignUpAdditionalData,
     required this.userType,
     required this.requireAdditionalSignUpFields,
-    this.onSwitchConfirmSignup,
+    required this.onSwitchConfirmSignup,
+    required this.requireSignUpConfirmation,
     this.onSwitchAuth,
     this.onSubmitCompleted,
     this.hideForgotPasswordButton = false,
@@ -24,7 +25,7 @@ class _LoginCard extends StatefulWidget {
   final FormFieldValidator<String>? passwordValidator;
   final Function onSwitchRecoveryPassword;
   final Function onSwitchSignUpAdditionalData;
-  final Function? onSwitchConfirmSignup;
+  final Function onSwitchConfirmSignup;
   final Function? onSwitchAuth;
   final Function? onSubmitCompleted;
   final bool hideForgotPasswordButton;
@@ -33,6 +34,7 @@ class _LoginCard extends StatefulWidget {
   final bool hideProvidersTitle;
   final LoginUserType userType;
   final bool requireAdditionalSignUpFields;
+  final bool requireSignUpConfirmation;
 
   @override
   _LoginCardState createState() => _LoginCardState();
@@ -202,35 +204,20 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
     }
 
     if (auth.isSignup) {
-      if (!widget.loginAfterSignUp && !widget.requireAdditionalSignUpFields) {
+      if (widget.requireAdditionalSignUpFields) {
+        widget.onSwitchSignUpAdditionalData();
+        // The login page wil be shown in login mode (used if loginAfterSignUp disabled)
+        _switchAuthMode();
+        return false;
+      } else if (widget.requireSignUpConfirmation) {
+        widget.onSwitchConfirmSignup();
+        _switchAuthMode();
+        return false;
+      } else if (!widget.loginAfterSignUp) {
         showSuccessToast(
             context, messages.flushbarTitleSuccess, messages.signUpSuccess);
         _switchAuthMode();
         setState(() => _isSubmitting = false);
-
-        return false;
-      } else if (widget.loginAfterSignUp &&
-          !widget.requireAdditionalSignUpFields &&
-          widget.onSwitchConfirmSignup != null) {
-        widget.onSwitchConfirmSignup!();
-      } else if (!widget.loginAfterSignUp &&
-          widget.requireAdditionalSignUpFields) {
-        // proceed to the card with the additional fields
-        widget.onSwitchSignUpAdditionalData();
-//FIRST
-        // The login page is shown in login mode
-        _switchAuthMode();
-
-        return false;
-      } else if (widget.loginAfterSignUp &&
-          widget.requireAdditionalSignUpFields &&
-          widget.onSwitchConfirmSignup != null) {
-        widget.onSwitchConfirmSignup!();
-      } else if (widget.loginAfterSignUp &&
-          widget.requireAdditionalSignUpFields) {
-        // proceed to the card with the additional fields
-        widget.onSwitchSignUpAdditionalData();
-
         return false;
       }
     }


### PR DESCRIPTION
- The signup confirmation page is now also shown when additionalSignupData is not provided or loginAfterSignUp is disabled.
- Back button of confirmSignUp page now returns Login or AdditionalSignUpData page depending on whether additionalSignupData has been provided or not.

Related to #280