### PR TITLE
Fixed the overflow caused by a long text in term of services with url link

### DIFF
--- a/lib/src/widgets/term_of_service_checkbox.dart
+++ b/lib/src/widgets/term_of_service_checkbox.dart
@@ -25,10 +25,12 @@ class _TermCheckboxState extends State<TermCheckbox> {
               child: Row(
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
-                  Text(
-                    widget.termOfService.text,
-                    style: Theme.of(context).textTheme.bodyText2,
-                    textAlign: TextAlign.left,
+                  Flexible(
+                    child: Text(
+                      widget.termOfService.text,
+                      style: Theme.of(context).textTheme.bodyText2,
+                      textAlign: TextAlign.left,
+                    ),
                   ),
                   Padding(
                     padding: const EdgeInsets.only(left: 8.0),


### PR DESCRIPTION
Related to #275

<img width="354" alt="Captura de pantalla 2021-11-21 a las 6 10 29" src="https://user-images.githubusercontent.com/55980347/142833001-409eb60d-37cc-4582-956b-3a9032317c26.png">
