### PR TITLE
Flutter 3 Null-aware warning fix

### DIFF
--- a/lib/src/widgets/animated_text.dart
+++ b/lib/src/widgets/animated_text.dart
@@ -54,7 +54,7 @@ class _AnimatedTextState extends State<AnimatedText>
 
     _oldText = widget.text;
 
-    WidgetsBinding.instance!.addPostFrameCallback((_) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
       setState(() => _layoutHeight = getWidgetSize(_textKey)?.height);
     });
   }


### PR DESCRIPTION
Fixes Flutter 3 warning of:
Warning: Operand of null-aware operation '!' has type 'WidgetsBinding' which excludes null.