### PR TITLE
Add possibility to to do some checks before additionalData are shown

### DIFF
--- a/lib/flutter_login.dart
+++ b/lib/flutter_login.dart
@@ -302,7 +302,8 @@ class FlutterLogin extends StatefulWidget {
       this.savedPassword = '',
       this.initialAuthMode = AuthMode.login,
       this.children,
-      this.scrollable = false})
+      this.scrollable = false,
+      this.beforeSwitchSignUpAdditionalData})
       : assert((logo is String?) || (logo is ImageProvider?)),
         logo = logo is String ? AssetImage(logo) : logo,
         super(key: key);
@@ -424,6 +425,12 @@ class FlutterLogin extends StatefulWidget {
   /// of resizing the window.
   /// Default: false
   final bool scrollable;
+
+  /// Called when the user hit the submit button when in sign up mode, before
+  /// additionalSignupFields are shown
+  /// Optional
+  final BeforeSwitchSignUpAdditionalDataCallback?
+      beforeSwitchSignUpAdditionalData;
 
   static String? defaultEmailValidator(value) {
     if (value!.isEmpty || !Regex.email.hasMatch(value)) {
@@ -763,6 +770,8 @@ class _FlutterLoginState extends State<FlutterLogin>
             confirmPassword: widget.savedPassword,
             onConfirmRecover: widget.onConfirmRecover,
             onConfirmSignup: widget.onConfirmSignup,
+            beforeSwitchSignUpAdditionalData:
+                widget.beforeSwitchSignUpAdditionalData,
             onResendCode: widget.onResendCode,
             termsOfService: widget.termsOfService,
             initialAuthMode: widget.initialAuthMode,

--- a/lib/src/providers/auth.dart
+++ b/lib/src/providers/auth.dart
@@ -37,6 +37,10 @@ typedef ConfirmSignupCallback = Future<String?>? Function(String, LoginData);
 /// The result is an error message, callback successes if message is null
 typedef ConfirmRecoverCallback = Future<String?>? Function(String, LoginData);
 
+/// The result is an error message, callback successes if message is null
+typedef BeforeSwitchSignUpAdditionalDataCallback = Future<String?>? Function(
+    SignupData);
+
 class Auth with ChangeNotifier {
   Auth(
       {this.loginProviders = const [],
@@ -46,6 +50,7 @@ class Auth with ChangeNotifier {
       this.onConfirmRecover,
       this.onConfirmSignup,
       this.onResendCode,
+      this.beforeSwitchSignUpAdditionalData,
       String email = '',
       String password = '',
       String confirmPassword = '',
@@ -64,6 +69,8 @@ class Auth with ChangeNotifier {
   final ConfirmSignupCallback? onConfirmSignup;
   final SignupCallback? onResendCode;
   final List<TermOfService> termsOfService;
+  final BeforeSwitchSignUpAdditionalDataCallback?
+      beforeSwitchSignUpAdditionalData;
 
   AuthType _authType = AuthType.userPassword;
 

--- a/lib/src/widgets/cards/login_card.dart
+++ b/lib/src/widgets/cards/login_card.dart
@@ -177,6 +177,14 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
             name: auth.email,
             password: auth.password,
             termsOfService: auth.getTermsOfServiceResults()));
+      } else {
+        if (auth.beforeSwitchSignUpAdditionalData != null) {
+          error = await auth.beforeSwitchSignUpAdditionalData!(
+              SignupData.fromSignupForm(
+                  name: auth.email,
+                  password: auth.password,
+                  termsOfService: auth.getTermsOfServiceResults()));
+        }
       }
     }
 


### PR DESCRIPTION
This feature allows to do some checks like validate login availability with the server before filling additional fields.
Right now the only way is to validate on submit and go back to the first card to change it.

Related to #316 