### PR TITLE
 IntroWidget

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ savedPassword |   `String`     | <sub>Prefilled value for password field (ie. sa
 termsOfService | [`TermOfService`](#TermOfService) | <sub>List of terms of service to be listed during registration. On onSignup callback LoginData contains a list of [`TermOfServiceResult`](#TermOfServiceResult) </sub>
 children | [`Widget`] | <sub>List of widgets that can be added to the stack of the login screen. Can be used to show custom banners or logos. </sub>
 scrollable |   `bool`     | <sub>When set to true, the login card becomes scrollable instead of resizing when needed.
+headerWidget |   `Widget`     | <sub>A widget that can be placed on top of the loginCard.</sub> 
 
 *NOTE:* It is recommended that the child widget of the `Hero` widget should be the
 same in both places. For title's hero animation use the

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.1'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Aug 02 15:41:30 CEST 2021
+#Wed Nov 09 09:53:18 CET 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/example/lib/login_screen.dart
+++ b/example/lib/login_screen.dart
@@ -268,7 +268,7 @@ class LoginScreen extends StatelessWidget {
         // Show new password dialog
       },
       showDebugButtons: false,
-      introWidget: const IntroWidget(),
+      headerWidget: const IntroWidget(),
     );
   }
 }
@@ -280,18 +280,13 @@ class IntroWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        Text.rich(
+        const Text.rich(
           TextSpan(children: [
-            const TextSpan(
+            TextSpan(
                 text: "You are trying to login/sign up on server hosted on "),
-            const TextSpan(
+            TextSpan(
                 text: "example.com",
                 style: TextStyle(fontWeight: FontWeight.bold)),
-            const TextSpan(text: ". "),
-            TextSpan(
-                text: "Click here",
-                style: TextStyle(color: Colors.blue.shade300)),
-            const TextSpan(text: " to change the server ")
           ]),
           textAlign: TextAlign.justify,
         ),

--- a/example/lib/login_screen.dart
+++ b/example/lib/login_screen.dart
@@ -267,7 +267,43 @@ class LoginScreen extends StatelessWidget {
         return _recoverPassword(name);
         // Show new password dialog
       },
-      showDebugButtons: true,
+      showDebugButtons: false,
+      introWidget: const IntroWidget(),
+    );
+  }
+}
+
+class IntroWidget extends StatelessWidget {
+  const IntroWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text.rich(
+          TextSpan(children: [
+            const TextSpan(
+                text: "You are trying to login/sign up on server hosted on "),
+            const TextSpan(
+                text: "example.com",
+                style: TextStyle(fontWeight: FontWeight.bold)),
+            const TextSpan(text: ". "),
+            TextSpan(
+                text: "Click here",
+                style: TextStyle(color: Colors.blue.shade300)),
+            const TextSpan(text: " to change the server ")
+          ]),
+          textAlign: TextAlign.justify,
+        ),
+        Row(children: const <Widget>[
+          Expanded(child: Divider()),
+          Padding(
+            padding: EdgeInsets.all(8.0),
+            child: Text("Authenticate"),
+          ),
+          Expanded(child: Divider()),
+        ]),
+      ],
     );
   }
 }

--- a/lib/flutter_login.dart
+++ b/lib/flutter_login.dart
@@ -302,7 +302,8 @@ class FlutterLogin extends StatefulWidget {
       this.savedPassword = '',
       this.initialAuthMode = AuthMode.login,
       this.children,
-      this.scrollable = false})
+      this.scrollable = false,
+      this.introWidget})
       : assert((logo is String?) || (logo is ImageProvider?)),
         logo = logo is String ? AssetImage(logo) : logo,
         super(key: key);
@@ -424,6 +425,10 @@ class FlutterLogin extends StatefulWidget {
   /// of resizing the window.
   /// Default: false
   final bool scrollable;
+
+  /// An IntroWidget that helps to place the navigation links
+  /// in case there is a possibility to navigate without login/signup
+  final Widget? introWidget;
 
   static String? defaultEmailValidator(value) {
     if (value!.isEmpty || !Regex.email.hasMatch(value)) {
@@ -809,6 +814,7 @@ class _FlutterLoginState extends State<FlutterLogin>
                         navigateBackAfterRecovery:
                             widget.navigateBackAfterRecovery,
                         scrollable: widget.scrollable,
+                        introWidget: widget.introWidget,
                       ),
                     ),
                     Positioned(

--- a/lib/flutter_login.dart
+++ b/lib/flutter_login.dart
@@ -304,7 +304,7 @@ class FlutterLogin extends StatefulWidget {
       this.children,
       this.scrollable = false,
       this.onSwitchToAdditionalFields,
-      this.introWidget})
+      this.headerWidget})
       : assert((logo is String?) || (logo is ImageProvider?)),
         logo = logo is String ? AssetImage(logo) : logo,
         super(key: key);
@@ -432,9 +432,8 @@ class FlutterLogin extends StatefulWidget {
   /// Default: false
   final bool scrollable;
 
-  /// An IntroWidget that helps to place the navigation links
-  /// in case there is a possibility to navigate without login/signup
-  final Widget? introWidget;
+  /// A widget that can be placed on top of the loginCard.
+  final Widget? headerWidget;
 
   static String? defaultEmailValidator(value) {
     if (value!.isEmpty || !Regex.email.hasMatch(value)) {
@@ -821,7 +820,7 @@ class _FlutterLoginState extends State<FlutterLogin>
                         navigateBackAfterRecovery:
                             widget.navigateBackAfterRecovery,
                         scrollable: widget.scrollable,
-                        introWidget: widget.introWidget,
+                        introWidget: widget.headerWidget,
                       ),
                     ),
                     Positioned(

--- a/lib/src/widgets/cards/auth_card_builder.dart
+++ b/lib/src/widgets/cards/auth_card_builder.dart
@@ -50,7 +50,8 @@ class AuthCard extends StatefulWidget {
       this.disableCustomPageTransformer = false,
       this.loginTheme,
       this.navigateBackAfterRecovery = false,
-      required this.scrollable})
+      required this.scrollable,
+      this.introWidget})
       : super(key: key);
 
   final EdgeInsets padding;
@@ -72,6 +73,7 @@ class AuthCard extends StatefulWidget {
   final bool navigateBackAfterRecovery;
 
   final bool scrollable;
+  final Widget? introWidget;
 
   @override
   AuthCardState createState() => AuthCardState();
@@ -341,6 +343,7 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
             hideForgotPasswordButton: widget.hideForgotPasswordButton,
             loginAfterSignUp: widget.loginAfterSignUp,
             hideProvidersTitle: widget.hideProvidersTitle,
+            introWidget: widget.introWidget,
           ),
         );
       case _recoveryIndex:

--- a/lib/src/widgets/cards/login_card.dart
+++ b/lib/src/widgets/cards/login_card.dart
@@ -17,6 +17,7 @@ class _LoginCard extends StatefulWidget {
     this.hideSignUpButton = false,
     this.loginAfterSignUp = true,
     this.hideProvidersTitle = false,
+    this.introWidget,
   }) : super(key: key);
 
   final AnimationController loadingController;
@@ -33,6 +34,7 @@ class _LoginCard extends StatefulWidget {
   final LoginUserType userType;
   final bool requireAdditionalSignUpFields;
   final bool requireSignUpConfirmation;
+  final Widget? introWidget;
 
   @override
   _LoginCardState createState() => _LoginCardState();
@@ -598,6 +600,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
+                if (widget.introWidget != null) widget.introWidget!,
                 _buildUserField(textFieldWidth, messages, auth),
                 const SizedBox(height: 20),
                 _buildPasswordField(textFieldWidth, messages, auth),


### PR DESCRIPTION
In my app, there are multiple servers. User can select a server before login. When I used flutter_login, I encountered a scenario in which, user has no way to go back to server selection screen if he accidentally selected a wrong server to login. 

To overcome this, I needed a widget that helps to navigate back. I introduced as IntroWidget for this, This widget can be placed before the Text fields and have logics to navigate away from the login screen. 

Please review and accept the change. If this can be addressed differently, please advise me.

Note, I have disabled debug buttons, intentionally. You may ignore that change.