### PR TITLE
Use .unfocus() instead of problematic dangling requestFocus(FocusNode())

### DIFF
--- a/lib/src/widgets/cards/additional_signup_card.dart
+++ b/lib/src/widgets/cards/additional_signup_card.dart
@@ -106,10 +106,7 @@ class _AdditionalSignUpCardState extends State<_AdditionalSignUpCard>
   }
 
   Future<bool> _submit() async {
-    // a hack to force unfocus the soft keyboard. If not, after change-route
-    // animation completes, it will trigger rebuilding this widget and show all
-    // textfields and buttons again before going to new route
-    FocusScope.of(context).requestFocus(FocusNode());
+    FocusScope.of(context).unfocus();
 
     final messages = Provider.of<LoginMessages>(context, listen: false);
 

--- a/lib/src/widgets/cards/login_card.dart
+++ b/lib/src/widgets/cards/login_card.dart
@@ -150,10 +150,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
   }
 
   Future<bool> _submit() async {
-    // a hack to force unfocus the soft keyboard. If not, after change-route
-    // animation completes, it will trigger rebuilding this widget and show all
-    // textfields and buttons again before going to new route
-    FocusScope.of(context).requestFocus(FocusNode());
+    FocusScope.of(context).unfocus();
 
     final messages = Provider.of<LoginMessages>(context, listen: false);
 

--- a/lib/src/widgets/cards/recover_confirm_card.dart
+++ b/lib/src/widgets/cards/recover_confirm_card.dart
@@ -46,7 +46,7 @@ class _ConfirmRecoverCardState extends State<_ConfirmRecoverCard>
   }
 
   Future<bool> _submit() async {
-    FocusScope.of(context).requestFocus(FocusNode()); // close keyboard
+    FocusScope.of(context).unfocus(); // close keyboard
 
     if (!_formRecoverKey.currentState!.validate()) {
       return false;

--- a/lib/src/widgets/cards/signup_confirm_card.dart
+++ b/lib/src/widgets/cards/signup_confirm_card.dart
@@ -47,7 +47,7 @@ class _ConfirmSignupCardState extends State<_ConfirmSignupCard>
   }
 
   Future<bool> _submit() async {
-    FocusScope.of(context).requestFocus(FocusNode());
+    FocusScope.of(context).unfocus();
 
     if (!_formRecoverKey.currentState!.validate()) {
       return false;
@@ -92,7 +92,7 @@ class _ConfirmSignupCardState extends State<_ConfirmSignupCard>
   }
 
   Future<bool> _resendCode() async {
-    FocusScope.of(context).requestFocus(FocusNode());
+    FocusScope.of(context).unfocus();
 
     final auth = Provider.of<Auth>(context, listen: false);
     final messages = Provider.of<LoginMessages>(context, listen: false);


### PR DESCRIPTION
Fixes #190, maybe other issues.

Calling `requestFocus(FocusNode())` leads to errors on e.g. the next call to ` FocusScope.of(context).requestFocus(_passwordFocusNode)`, because the `FocusNode` used for the hack is not attached to any `context`.