### PR TITLE
Fix: CheckboxFormField onChanged not updating value

### DIFF
--- a/lib/src/widgets/term_of_service_checkbox.dart
+++ b/lib/src/widgets/term_of_service_checkbox.dart
@@ -20,7 +20,9 @@ class _TermCheckboxState extends State<TermCheckbox> {
   @override
   Widget build(BuildContext context) {
     return CheckboxFormField(
-      onChanged: (value) => widget.termOfService.checked,
+      onChanged: (value) {
+        widget.termOfService.checked = value ?? false;
+      },
       initialValue: widget.termOfService.initialValue,
       title: widget.termOfService.linkUrl != null
           ? InkWell(


### PR DESCRIPTION
Fixing #364 

Fixing a bug that prevented CheckboxFormField to update its value onChanged. This was caused by a missing null check on the onChanged method. Added a null check and provided ´false´ as default value to ensure ´mandatory´ TermsOfService are handled correctly.