### PR TITLE
Field submit controller dispose() method must be called before super.dispose()

### DIFF
--- a/lib/src/widgets/cards/signup_confirm_card.dart
+++ b/lib/src/widgets/cards/signup_confirm_card.dart
@@ -42,8 +42,8 @@ class _ConfirmSignupCardState extends State<_ConfirmSignupCard>
 
   @override
   void dispose() {
-    super.dispose();
     _fieldSubmitController.dispose();
+    super.dispose();
   }
 
   Future<bool> _submit() async {


### PR DESCRIPTION
Field submit controller dispose() method must be called before super.dispose().
Issue found by crashlytics.