### PR TITLE
Fix issue of additional signup fields not showing up, when using OAuth Provider

### DIFF
--- a/lib/src/widgets/cards/login_card.dart
+++ b/lib/src/widgets/cards/login_card.dart
@@ -335,7 +335,6 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
       widget.onSubmitCompleted!();
     }
     await control?.reverse();
-    widget.onSubmitCompleted!();
     return true;
   }
 


### PR DESCRIPTION
Hi,
thanks a lot for this awesome plugin! I like the look and feel very much and appreciate the effort everyone has put into it!

I noticed that the Social Providers / OAuth flow has an issue, when you want to show the additional signup fields (form). They do not show up, but instead flow is directly completed.

Here it was probably still working: [login_card.dart](https://github.com/NearHuscarl/flutter_login/commit/f272949470bf88d43bf6975b4e007d07bd5b7548)

but here the last ` widget.onSubmitCompleted!();` before the return, skips the additional sign up fields flow:
[login_card.dart](https://github.com/NearHuscarl/flutter_login/commit/10b8447be3238b2f105c1d452679a1dd3cb05ea5)