### PR TITLE
Add Checkbox version v2

### DIFF
--- a/example/lib/login_screen.dart
+++ b/example/lib/login_screen.dart
@@ -102,13 +102,13 @@ class LoginScreen extends StatelessWidget {
         ),
       ],
       additionalSignupFields: [
-        const UserFormField(
+        const UserTextFormField(
           keyName: 'Username',
           icon: Icon(FontAwesomeIcons.userLarge),
         ),
-        const UserFormField(keyName: 'Name'),
-        const UserFormField(keyName: 'Surname'),
-        UserFormField(
+        const UserTextFormField(keyName: 'Name'),
+        const UserTextFormField(keyName: 'Surname'),
+        UserTextFormField(
           keyName: 'phone_number',
           displayName: 'Phone Number',
           userType: LoginUserType.phone,
@@ -116,13 +116,16 @@ class LoginScreen extends StatelessWidget {
             final phoneRegExp = RegExp(
               '^(\\+\\d{1,2}\\s)?\\(?\\d{3}\\)?[\\s.-]?\\d{3}[\\s.-]?\\d{4}\$',
             );
-            if (value != null &&
-                value.length < 7 &&
-                !phoneRegExp.hasMatch(value)) {
+            if (value != null && value.length < 7 && !phoneRegExp.hasMatch(value)) {
               return "This isn't a valid phone number";
             }
             return null;
           },
+        ),
+        UserCheckboxFormField(
+          keyName: 'newsletter',
+          validator: (value) => value == false ? 'You need to accept the newsletter, so that we can inform you' : null,
+          displayName: 'Subscribe to our newsletter',
         ),
       ],
       // scrollable: true,
@@ -284,9 +287,9 @@ class IntroWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
+    return const Column(
       children: [
-        const Text.rich(
+        Text.rich(
           TextSpan(
             children: [
               TextSpan(
@@ -301,7 +304,7 @@ class IntroWidget extends StatelessWidget {
           textAlign: TextAlign.justify,
         ),
         Row(
-          children: const <Widget>[
+          children: <Widget>[
             Expanded(child: Divider()),
             Padding(
               padding: EdgeInsets.all(8.0),

--- a/lib/src/models/user_form_field.dart
+++ b/lib/src/models/user_form_field.dart
@@ -23,13 +23,13 @@ class UserCheckboxFormField extends UserFormField {
   final String? linkUrl;
 
   /// The validator of the checkbox
-  final FormFieldValidator<bool> validator;
+  final FormFieldValidator<bool>? validator;
 
   final InlineSpan? tooltip;
 
   const UserCheckboxFormField({
     required super.keyName,
-    required this.validator,
+    this.validator,
     super.displayName,
     this.tooltip,
     this.linkUrl,

--- a/lib/src/models/user_form_field.dart
+++ b/lib/src/models/user_form_field.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_login/src/models/login_user_type.dart';
 
-class UserFormField {
+abstract class UserFormField {
   /// The name of the field retrieved as key.
   /// Please ensure this is unique, otherwise an Error will be thrown
   final String keyName;
@@ -9,9 +9,35 @@ class UserFormField {
   /// The name of the field displayed on the form. Defaults to `keyName` if not given
   final String displayName;
 
-  /// The default value of the field
-  final String defaultValue;
+  const UserFormField({
+    required this.keyName,
+    String? displayName,
+  }) : displayName = displayName ?? keyName;
+}
 
+class UserCheckboxFormField extends UserFormField {
+  /// The initial value of the checkbox
+  final bool initialValue;
+
+  /// Url to open when the user taps on the title
+  final String? linkUrl;
+
+  /// The validator of the checkbox
+  final FormFieldValidator<bool> validator;
+
+  final InlineSpan? tooltip;
+
+  const UserCheckboxFormField({
+    required super.keyName,
+    required this.validator,
+    super.displayName,
+    this.tooltip,
+    this.linkUrl,
+    this.initialValue = false,
+  });
+}
+
+class UserTextFormField extends UserFormField {
   /// A function to validate the field.
   /// It should return null on success, or a string with the explanation of the error
   final FormFieldValidator<String>? fieldValidator;
@@ -23,15 +49,18 @@ class UserFormField {
   /// Defaults to LoginUserType.user
   final LoginUserType userType;
 
+  /// The default value of the field
+  final String defaultValue;
+
   final InlineSpan? tooltip;
 
-  const UserFormField({
-    required this.keyName,
-    String? displayName,
+  const UserTextFormField({
+    required super.keyName,
+    super.displayName,
     this.defaultValue = '',
     this.icon,
     this.fieldValidator,
     this.userType = LoginUserType.name,
     this.tooltip,
-  }) : displayName = displayName ?? keyName;
+  });
 }

--- a/lib/src/widgets/animated_checkbox_form_field.dart
+++ b/lib/src/widgets/animated_checkbox_form_field.dart
@@ -40,7 +40,7 @@ class AnimatedCheckboxFormField extends StatefulWidget {
   final double width;
   final bool enabled;
   final String? labelText;
-  final FormFieldValidator<bool> validator;
+  final FormFieldValidator<bool>? validator;
   final bool initialValue;
   final ValueChanged<bool?> onChanged;
   final String? linkUrl;
@@ -128,7 +128,7 @@ class _AnimatedCheckboxFormFieldState extends State<AnimatedCheckboxFormField> {
     final theme = Theme.of(context);
     Widget textField = CheckboxFormField(
       initialValue: widget.initialValue,
-      validator: widget.validator,
+      validator: widget.validator ?? (_) => null,
       onChanged: widget.onChanged,
       title: widget.linkUrl != null
           ? InkWell(

--- a/lib/src/widgets/animated_checkbox_form_field.dart
+++ b/lib/src/widgets/animated_checkbox_form_field.dart
@@ -1,0 +1,219 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_login/src/widgets/term_of_service_checkbox.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+Interval _getInternalInterval(
+  double start,
+  double end,
+  double externalStart,
+  double externalEnd, [
+  Curve curve = Curves.linear,
+]) {
+  return Interval(
+    start + (end - start) * externalStart,
+    start + (end - start) * externalEnd,
+    curve: curve,
+  );
+}
+
+class AnimatedCheckboxFormField extends StatefulWidget {
+  const AnimatedCheckboxFormField({
+    required this.width,
+    required this.validator,
+    required this.onChanged,
+    super.key,
+    this.textFormFieldKey,
+    this.linkUrl,
+    this.interval = const Interval(0.0, 1.0),
+    this.loadingController,
+    this.inertiaController,
+    this.enabled = true,
+    this.initialValue = false,
+    this.labelText,
+    this.tooltip,
+  });
+
+  final Key? textFormFieldKey;
+  final Interval? interval;
+  final AnimationController? loadingController;
+  final AnimationController? inertiaController;
+  final double width;
+  final bool enabled;
+  final String? labelText;
+  final FormFieldValidator<bool> validator;
+  final bool initialValue;
+  final ValueChanged<bool?> onChanged;
+  final String? linkUrl;
+  final InlineSpan? tooltip;
+
+  @override
+  State<AnimatedCheckboxFormField> createState() => _AnimatedCheckboxFormFieldState();
+}
+
+class _AnimatedCheckboxFormFieldState extends State<AnimatedCheckboxFormField> {
+  late Animation<double> scaleAnimation;
+  late Animation<double> sizeAnimation;
+  late Animation<double> suffixIconOpacityAnimation;
+
+  late Animation<double> fieldTranslateAnimation;
+  late Animation<double> iconRotationAnimation;
+  late Animation<double> iconTranslateAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+
+    final interval = widget.interval;
+    final loadingController = widget.loadingController;
+
+    if (loadingController != null) {
+      scaleAnimation = Tween<double>(
+        begin: 0.0,
+        end: 1.0,
+      ).animate(
+        CurvedAnimation(
+          parent: loadingController,
+          curve: _getInternalInterval(
+            0,
+            .2,
+            interval!.begin,
+            interval.end,
+            Curves.easeOutBack,
+          ),
+        ),
+      );
+      suffixIconOpacityAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(
+        CurvedAnimation(
+          parent: loadingController,
+          curve: _getInternalInterval(.65, 1.0, interval.begin, interval.end),
+        ),
+      );
+      _updateSizeAnimation();
+    }
+  }
+
+  void _updateSizeAnimation() {
+    final interval = widget.interval!;
+    final loadingController = widget.loadingController!;
+
+    sizeAnimation = Tween<double>(
+      begin: 48.0,
+      end: widget.width,
+    ).animate(
+      CurvedAnimation(
+        parent: loadingController,
+        curve: _getInternalInterval(
+          .2,
+          1.0,
+          interval.begin,
+          interval.end,
+          Curves.linearToEaseOut,
+        ),
+        reverseCurve: Curves.easeInExpo,
+      ),
+    );
+  }
+
+  @override
+  void didUpdateWidget(AnimatedCheckboxFormField oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.width != widget.width) {
+      _updateSizeAnimation();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    Widget textField = CheckboxFormField(
+      initialValue: widget.initialValue,
+      validator: widget.validator,
+      onChanged: widget.onChanged,
+      title: widget.linkUrl != null
+          ? InkWell(
+              onTap: () {
+                launchUrl(Uri.parse(widget.linkUrl!));
+              },
+              child: Row(
+                children: [
+                  Flexible(
+                    child: Text(
+                      widget.labelText ?? '',
+                      style: Theme.of(context).textTheme.bodyMedium,
+                      textAlign: TextAlign.left,
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.only(left: 8.0),
+                    child: Icon(
+                      Icons.open_in_new,
+                      color: Theme.of(context).textTheme.bodyMedium!.color,
+                      size: Theme.of(context).textTheme.bodyMedium!.fontSize,
+                    ),
+                  )
+                ],
+              ),
+            )
+          : Text(
+              widget.labelText ?? '',
+              style: Theme.of(context).textTheme.bodyMedium,
+              textAlign: TextAlign.left,
+            ),
+    );
+
+    if (widget.tooltip != null) {
+      final tooltipKey = GlobalKey<TooltipState>();
+      final tooltip = Tooltip(
+        key: tooltipKey,
+        richMessage: widget.tooltip,
+        showDuration: const Duration(seconds: 30),
+        triggerMode: TooltipTriggerMode.manual,
+        margin: const EdgeInsets.all(4),
+        child: textField,
+      );
+      textField = Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Flexible(
+            child: tooltip,
+          ),
+          IconButton(
+            padding: EdgeInsets.zero,
+            onPressed: () => tooltipKey.currentState?.ensureTooltipVisible(),
+            color: theme.primaryColor,
+            iconSize: 28,
+            icon: const Icon(Icons.info),
+          )
+        ],
+      );
+    }
+
+    if (widget.loadingController != null) {
+      textField = ScaleTransition(
+        scale: scaleAnimation,
+        child: AnimatedBuilder(
+          animation: sizeAnimation,
+          builder: (context, child) => ConstrainedBox(
+            constraints: BoxConstraints.tightFor(width: sizeAnimation.value),
+            child: child,
+          ),
+          child: textField,
+        ),
+      );
+    }
+
+    if (widget.inertiaController != null) {
+      textField = AnimatedBuilder(
+        animation: fieldTranslateAnimation,
+        builder: (context, child) => Transform.translate(
+          offset: Offset(fieldTranslateAnimation.value, 0),
+          child: child,
+        ),
+        child: textField,
+      );
+    }
+
+    return textField;
+  }
+}

--- a/lib/src/widgets/cards/additional_signup_card.dart
+++ b/lib/src/widgets/cards/additional_signup_card.dart
@@ -202,6 +202,7 @@ class _AdditionalSignUpCardState extends State<_AdditionalSignUpCard> with Ticke
                 loadingController: widget.loadingController,
                 width: width,
                 labelText: formField.displayName,
+                linkUrl: formField.linkUrl,
                 validator: formField.validator,
                 tooltip: formField.tooltip,
                 onChanged: (value) => _checkboxValues[formField.keyName] = value ?? false,

--- a/lib/src/widgets/cards/auth_card_builder.dart
+++ b/lib/src/widgets/cards/auth_card_builder.dart
@@ -13,6 +13,7 @@ import 'package:flutter_login/src/paddings.dart';
 import 'package:flutter_login/src/utils/text_field_utils.dart';
 import 'package:flutter_login/src/widget_helper.dart';
 import 'package:flutter_login/src/widgets/animated_button.dart';
+import 'package:flutter_login/src/widgets/animated_checkbox_form_field.dart';
 import 'package:flutter_login/src/widgets/animated_icon.dart';
 import 'package:flutter_login/src/widgets/animated_text.dart';
 import 'package:flutter_login/src/widgets/animated_text_form_field.dart';
@@ -142,8 +143,7 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
       duration: const Duration(milliseconds: 1100),
     );
 
-    _cardSizeAnimation =
-        Tween<double>(begin: 1.0, end: cardSizeScaleEnd).animate(
+    _cardSizeAnimation = Tween<double>(begin: 1.0, end: cardSizeScaleEnd).animate(
       CurvedAnimation(
         parent: _routeTransitionController,
         curve: const Interval(
@@ -156,27 +156,23 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
 
     // replace 0 with minPositive to pass the test
     // https://github.com/flutter/flutter/issues/42527#issuecomment-575131275
-    _cardOverlayHeightFactorAnimation =
-        Tween<double>(begin: double.minPositive, end: 1.0).animate(
+    _cardOverlayHeightFactorAnimation = Tween<double>(begin: double.minPositive, end: 1.0).animate(
       CurvedAnimation(
         parent: _routeTransitionController,
         curve: const Interval(.27272727, .5),
       ),
     );
 
-    _cardOverlaySizeAndOpacityAnimation =
-        Tween<double>(begin: 1.0, end: 0).animate(
+    _cardOverlaySizeAndOpacityAnimation = Tween<double>(begin: 1.0, end: 0).animate(
       CurvedAnimation(
         parent: _routeTransitionController,
         curve: const Interval(.5, .72727272),
       ),
     );
 
-    _cardSize2AnimationX =
-        Tween<double>(begin: 1, end: 1).animate(_routeTransitionController);
+    _cardSize2AnimationX = Tween<double>(begin: 1, end: 1).animate(_routeTransitionController);
 
-    _cardSize2AnimationY =
-        Tween<double>(begin: 1, end: 1).animate(_routeTransitionController);
+    _cardSize2AnimationY = Tween<double>(begin: 1, end: 1).animate(_routeTransitionController);
 
     _cardRotationAnimation = Tween<double>(begin: 0, end: pi / 2).animate(
       CurvedAnimation(
@@ -221,9 +217,7 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
         }
       });
     } else if (widget.loadingController.isCompleted) {
-      return _formLoadingController
-          .reverse()
-          .then((_) => widget.loadingController.reverse());
+      return _formLoadingController.reverse().then((_) => widget.loadingController.reverse());
     }
     return null;
   }
@@ -234,15 +228,13 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
     final widthRatio = deviceSize.width / cardSize.height + 2;
     final heightRatio = deviceSize.height / cardSize.width + .25;
 
-    _cardSize2AnimationX =
-        Tween<double>(begin: 1.0, end: heightRatio / cardSizeScaleEnd).animate(
+    _cardSize2AnimationX = Tween<double>(begin: 1.0, end: heightRatio / cardSizeScaleEnd).animate(
       CurvedAnimation(
         parent: _routeTransitionController,
         curve: const Interval(.72727272, 1, curve: Curves.easeInOutCubic),
       ),
     );
-    _cardSize2AnimationY =
-        Tween<double>(begin: 1.0, end: widthRatio / cardSizeScaleEnd).animate(
+    _cardSize2AnimationY = Tween<double>(begin: 1.0, end: widthRatio / cardSizeScaleEnd).animate(
       CurvedAnimation(
         parent: _routeTransitionController,
         curve: const Interval(.72727272, 1, curve: Curves.easeInOutCubic),
@@ -251,15 +243,11 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
 
     widget.onSubmit?.call();
 
-    return _formLoadingController
-        .reverse()
-        .then((_) => _routeTransitionController.forward());
+    return _formLoadingController.reverse().then((_) => _routeTransitionController.forward());
   }
 
   void _reverseChangeRouteAnimation() {
-    _routeTransitionController
-        .reverse()
-        .then((_) => _formLoadingController.forward());
+    _routeTransitionController.reverse().then((_) => _formLoadingController.forward());
   }
 
   void runChangeRouteAnimation() {
@@ -355,11 +343,9 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
             userValidator: widget.userValidator,
             validateUserImmediately: widget.validateUserImmediately,
             passwordValidator: widget.passwordValidator,
-            requireAdditionalSignUpFields:
-                widget.additionalSignUpFields != null,
+            requireAdditionalSignUpFields: widget.additionalSignUpFields != null,
             onSwitchRecoveryPassword: () => _changeCard(_recoveryIndex),
-            onSwitchSignUpAdditionalData: () =>
-                _changeCard(_additionalSignUpIndex),
+            onSwitchSignUpAdditionalData: () => _changeCard(_additionalSignUpIndex),
             onSubmitCompleted: () {
               _forwardChangeRouteAnimation(_loginCardKey).then((_) {
                 widget.onSubmitCompleted!();
@@ -405,13 +391,11 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
             onBack: () => _changeCard(_loginPageIndex),
             loginTheme: widget.loginTheme,
             onSubmitCompleted: () async {
-              final requireSignupConfirmation =
-                  await requireSignUpConfirmation();
+              final requireSignupConfirmation = await requireSignUpConfirmation();
               if (requireSignupConfirmation) {
                 _changeCard(_confirmSignup);
               } else if (widget.loginAfterSignUp) {
-                _forwardChangeRouteAnimation(_additionalSignUpCardKey)
-                    .then((_) {
+                _forwardChangeRouteAnimation(_additionalSignUpCardKey).then((_) {
                   widget.onSubmitCompleted!();
                 });
               } else {
@@ -434,9 +418,8 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
           theme: Theme.of(context),
           child: _ConfirmSignupCard(
             key: _confirmSignUpCardKey,
-            onBack: () => auth.additionalSignupData == null
-                ? _changeCard(_loginPageIndex)
-                : _changeCard(_additionalSignUpIndex),
+            onBack: () =>
+                auth.additionalSignupData == null ? _changeCard(_loginPageIndex) : _changeCard(_additionalSignUpIndex),
             loadingController: formController,
             onSubmitCompleted: () {
               if (widget.loginAfterSignUp) {
@@ -471,9 +454,7 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
         /// Need to keep track of page index because soft keyboard will
         /// make page view rebuilt
         index: _pageIndex,
-        transformer: widget.disableCustomPageTransformer
-            ? null
-            : CustomPageTransformer(),
+        transformer: widget.disableCustomPageTransformer ? null : CustomPageTransformer(),
         itemBuilder: (BuildContext context, int index) {
           if (widget.scrollable) {
             return Align(

--- a/lib/src/widgets/cards/login_card.dart
+++ b/lib/src/widgets/cards/login_card.dart
@@ -107,8 +107,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
 
     _nameTextFieldLoadingAnimationInterval = const Interval(0, .85);
     _passTextFieldLoadingAnimationInterval = const Interval(.15, 1.0);
-    _textButtonLoadingAnimationInterval =
-        const Interval(.6, 1.0, curve: Curves.easeOut);
+    _textButtonLoadingAnimationInterval = const Interval(.6, 1.0, curve: Curves.easeOut);
     _buttonScaleAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(
       CurvedAnimation(
         parent: widget.loadingController,
@@ -117,8 +116,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
     );
 
     _userFocusNode.addListener(() {
-      if (!_userFocusNode.hasFocus &&
-          (widget.validateUserImmediately ?? false)) {
+      if (!_userFocusNode.hasFocus && (widget.validateUserImmediately ?? false)) {
         _userFieldKey.currentState?.validate();
       }
     });
@@ -229,8 +227,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
     }
 
     if (auth.isSignup) {
-      final requireSignUpConfirmation =
-          await widget.requireSignUpConfirmation();
+      final requireSignUpConfirmation = await widget.requireSignUpConfirmation();
       if (widget.requireAdditionalSignUpFields) {
         widget.onSwitchSignUpAdditionalData();
         // The login page wil be shown in login mode (used if loginAfterSignUp disabled)
@@ -305,8 +302,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
       return false;
     }
 
-    final showSignupAdditionalFields =
-        await loginProvider.providerNeedsSignUpCallback?.call() ?? false;
+    final showSignupAdditionalFields = await loginProvider.providerNeedsSignUpCallback?.call() ?? false;
 
     if (showSignupAdditionalFields) {
       if (auth.beforeAdditionalFieldsCallback != null) {
@@ -335,7 +331,6 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
       widget.onSubmitCompleted!();
     }
     await control?.reverse();
-    widget.onSubmitCompleted!();
     return true;
   }
 
@@ -351,11 +346,8 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
       width: width,
       loadingController: widget.loadingController,
       interval: _nameTextFieldLoadingAnimationInterval,
-      labelText:
-          messages.userHint ?? TextFieldUtils.getLabelText(widget.userType),
-      autofillHints: _isSubmitting
-          ? null
-          : [TextFieldUtils.getAutofillHints(widget.userType)],
+      labelText: messages.userHint ?? TextFieldUtils.getLabelText(widget.userType),
+      autofillHints: _isSubmitting ? null : [TextFieldUtils.getAutofillHints(widget.userType)],
       prefixIcon: TextFieldUtils.getPrefixIcon(widget.userType),
       keyboardType: TextFieldUtils.getKeyboardType(widget.userType),
       textInputAction: TextInputAction.next,
@@ -375,14 +367,9 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
       loadingController: widget.loadingController,
       interval: _passTextFieldLoadingAnimationInterval,
       labelText: messages.passwordHint,
-      autofillHints: _isSubmitting
-          ? null
-          : (auth.isLogin
-              ? [AutofillHints.password]
-              : [AutofillHints.newPassword]),
+      autofillHints: _isSubmitting ? null : (auth.isLogin ? [AutofillHints.password] : [AutofillHints.newPassword]),
       controller: _passController,
-      textInputAction:
-          auth.isLogin ? TextInputAction.done : TextInputAction.next,
+      textInputAction: auth.isLogin ? TextInputAction.done : TextInputAction.next,
       focusNode: _passwordFocusNode,
       onFieldSubmitted: (value) {
         if (auth.isLogin) {
@@ -470,10 +457,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
     Auth auth,
     LoginTheme loginTheme,
   ) {
-    final calculatedTextColor =
-        (theme.cardTheme.color!.computeLuminance() < 0.5)
-            ? Colors.white
-            : theme.primaryColor;
+    final calculatedTextColor = (theme.cardTheme.color!.computeLuminance() < 0.5) ? Colors.white : theme.primaryColor;
     return FadeIn(
       controller: widget.loadingController,
       offset: .5,
@@ -482,8 +466,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
       child: MaterialButton(
         disabledTextColor: theme.primaryColor,
         onPressed: buttonEnabled ? _switchAuthMode : null,
-        padding: loginTheme.authButtonPadding ??
-            const EdgeInsets.symmetric(horizontal: 30.0, vertical: 8.0),
+        padding: loginTheme.authButtonPadding ?? const EdgeInsets.symmetric(horizontal: 30.0, vertical: 8.0),
         materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
         textColor: loginTheme.switchAuthTextColor ?? calculatedTextColor,
         child: AnimatedText(
@@ -541,8 +524,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
             button: loginProvider.button,
             callback: loginProvider.callback,
             animated: loginProvider.animated,
-            providerNeedsSignUpCallback:
-                loginProvider.providerNeedsSignUpCallback,
+            providerNeedsSignUpCallback: loginProvider.providerNeedsSignUpCallback,
           ),
         );
       } else if (loginProvider.icon != null) {
@@ -553,8 +535,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
             button: loginProvider.button,
             callback: loginProvider.callback,
             animated: loginProvider.animated,
-            providerNeedsSignUpCallback:
-                loginProvider.providerNeedsSignUpCallback,
+            providerNeedsSignUpCallback: loginProvider.providerNeedsSignUpCallback,
           ),
         );
       }
@@ -563,10 +544,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
       return Column(
         children: [
           _buildButtonColumn(theme, messages, buttonProvidersList, loginTheme),
-          if (iconProvidersList.isNotEmpty)
-            _buildProvidersTitleSecond(messages)
-          else
-            Container(),
+          if (iconProvidersList.isNotEmpty) _buildProvidersTitleSecond(messages) else Container(),
           _buildIconRow(theme, messages, iconProvidersList, loginTheme),
         ],
       );
@@ -586,8 +564,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
       mainAxisAlignment: MainAxisAlignment.center,
       children: buttonProvidersList.map((loginProvider) {
         return Padding(
-          padding: loginTheme.providerButtonPadding ??
-              const EdgeInsets.symmetric(horizontal: 6.0, vertical: 8.0),
+          padding: loginTheme.providerButtonPadding ?? const EdgeInsets.symmetric(horizontal: 6.0, vertical: 8.0),
           child: ScaleTransition(
             scale: _buttonScaleAnimation,
             child: SignInButton(
@@ -614,8 +591,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
       children: iconProvidersList.map((loginProvider) {
         final index = iconProvidersList.indexOf(loginProvider);
         return Padding(
-          padding: loginTheme.providerButtonPadding ??
-              const EdgeInsets.symmetric(horizontal: 6.0, vertical: 8.0),
+          padding: loginTheme.providerButtonPadding ?? const EdgeInsets.symmetric(horizontal: 6.0, vertical: 8.0),
           child: ScaleTransition(
             scale: _buttonScaleAnimation,
             child: Column(
@@ -706,13 +682,9 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
             ),
           ),
           ExpandableContainer(
-            backgroundColor: _switchAuthController.isCompleted
-                ? null
-                : theme.colorScheme.secondary,
+            backgroundColor: _switchAuthController.isCompleted ? null : theme.colorScheme.secondary,
             controller: _switchAuthController,
-            initialState: isLogin
-                ? ExpandableContainerState.shrunk
-                : ExpandableContainerState.expanded,
+            initialState: isLogin ? ExpandableContainerState.shrunk : ExpandableContainerState.expanded,
             alignment: Alignment.topLeft,
             color: theme.cardTheme.color,
             width: cardWidth,
@@ -754,8 +726,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
                   SizedBox.fromSize(
                     size: const Size.fromHeight(10),
                   ),
-                if (auth.loginProviders.isNotEmpty &&
-                    !widget.hideProvidersTitle)
+                if (auth.loginProviders.isNotEmpty && !widget.hideProvidersTitle)
                   _buildProvidersTitleFirst(messages)
                 else
                   Container(),

--- a/test/flutter_login_test.dart
+++ b/test/flutter_login_test.dart
@@ -695,11 +695,11 @@ void main() {
             passwordValidator: mockCallback.passwordValidator,
             onSubmitAnimationCompleted: mockCallback.onSubmitAnimationCompleted,
             additionalSignupFields: <UserFormField>[
-              UserFormField(
+              UserTextFormField(
                 keyName: 'Name',
                 fieldValidator: mockCallback.userValidator,
               ),
-              UserFormField(
+              UserTextFormField(
                 keyName: 'Surname',
                 fieldValidator: mockCallback.userValidator,
               ),
@@ -1094,8 +1094,8 @@ void main() {
             onRecoverPassword: (data) => null,
             passwordValidator: (value) => null,
             additionalSignupFields: const [
-              UserFormField(keyName: 'Name'),
-              UserFormField(keyName: 'Surname'),
+              UserTextFormField(keyName: 'Name'),
+              UserTextFormField(keyName: 'Surname'),
             ],
           ),
         );
@@ -1148,8 +1148,8 @@ void main() {
             onRecoverPassword: (data) => null,
             passwordValidator: (value) => null,
             additionalSignupFields: const [
-              UserFormField(keyName: 'Name'),
-              UserFormField(keyName: 'Surname'),
+              UserTextFormField(keyName: 'Name'),
+              UserTextFormField(keyName: 'Surname'),
             ],
           ),
         );
@@ -1194,11 +1194,10 @@ void main() {
             onRecoverPassword: (data) => null,
             passwordValidator: (value) => null,
             additionalSignupFields: const [
-              UserFormField(keyName: 'Name'),
-              UserFormField(keyName: 'Surname'),
+              UserTextFormField(keyName: 'Name'),
+              UserTextFormField(keyName: 'Surname'),
             ],
-            onSubmitAnimationCompleted: () =>
-                onSubmitAnimationCompletedExecuted = true,
+            onSubmitAnimationCompleted: () => onSubmitAnimationCompletedExecuted = true,
           ),
         );
 


### PR DESCRIPTION
This PR is trying to add checkbox functionality to the additional signup fields with the fewest changes possible. Why is this needed, instead of using Terms: When you do the OAuth flow, you might still want to add checkboxes for Newsletter-acceptance etc.

This is the more integrated version, but it comes along with API changes, opposed to: https://github.com/NearHuscarl/flutter_login/pull/422