### PR TITLE
Added dynamic prefix-icon on recover card based on user type.

### DIFF
--- a/lib/src/widgets/cards/recover_card.dart
+++ b/lib/src/widgets/cards/recover_card.dart
@@ -93,7 +93,7 @@ class _RecoverCardState extends State<_RecoverCard>
       userType: widget.userType,
       width: width,
       labelText: messages.userHint,
-      prefixIcon: const Icon(FontAwesomeIcons.solidCircleUser),
+      prefixIcon: TextFieldUtils.getPrefixIcon(widget.userType),
       keyboardType: TextFieldUtils.getKeyboardType(widget.userType),
       autofillHints: [TextFieldUtils.getAutofillHints(widget.userType)],
       textInputAction: TextInputAction.done,


### PR DESCRIPTION
When userType parameter is set to `email` and we click on Forgot Password button, the icon showed on the form is fixed to `UserCircle` and does not change as in the login form.

This could be confusing to users, especially if the textfield is blank as is not clear they should put their email.