### PR TITLE
Fix navigation to login page after pressing sign up confirm button.

### DIFF
--- a/lib/src/widgets/cards/signup_confirm_card.dart
+++ b/lib/src/widgets/cards/signup_confirm_card.dart
@@ -83,7 +83,7 @@ class _ConfirmSignupCardState extends State<_ConfirmSignupCard>
 
     if (!widget.loginAfterSignUp) {
       auth.mode = AuthMode.login;
-      widget.onBack();
+      widget.onSubmitCompleted();
       return false;
     }
 


### PR DESCRIPTION
When **loginAfterSignUp** is disabled, it should return to login page after pressing sign up comfirm button instead of returning to **additionalSignUpCard** page, if **additionalSignupData** is not null.