### PR TITLE
BLoC state management modifications

### DIFF
--- a/lib/flutter_login.dart
+++ b/lib/flutter_login.dart
@@ -317,6 +317,9 @@ class FlutterLogin extends StatefulWidget {
     this.isBlocPattern = false,
     this.loginStateController,
     this.signupState = 0,
+    this.onChangedUserField,
+    this.onChangedPasswordField,
+    this.onChangedConfirmPasswordField,
   })  : assert((logo is String?) || (logo is ImageProvider?)),
         logo = logo is String ? AssetImage(logo) : logo as ImageProvider?;
 
@@ -334,6 +337,21 @@ class FlutterLogin extends StatefulWidget {
   ///
   /// Singup submit transition animation
   final int? signupState;
+
+  /// Exposed onChanged to modify dinamically the bloc states information
+  ///
+  /// User Field onChanged logic
+  final FormFieldSetter<String>? onChangedUserField;
+
+  /// Exposed onChanged to modify dinamically the bloc states information
+  ///
+  /// Password Field onChanged logic
+  final FormFieldSetter<String>? onChangedPasswordField;
+
+  /// Exposed onChanged to modify dinamically the bloc states information
+  ///
+  /// Confirm Password Field onChanged logic
+  final FormFieldSetter<String>? onChangedConfirmPasswordField;
 
   /// Called when the user hit the submit button when in sign up mode
   ///
@@ -873,6 +891,10 @@ class _FlutterLoginState extends State<FlutterLogin>
                         initialIsoCode: widget.initialIsoCode,
                         isBlocPattern: widget.isBlocPattern,
                         loginStateController: widget.loginStateController,
+                        onChangedConfirmPasswordField:
+                            widget.onChangedConfirmPasswordField,
+                        onChangedPasswordField: widget.onChangedPasswordField,
+                        onChangedUserField: widget.onChangedUserField,
                       ),
                     ),
                     Positioned(

--- a/lib/flutter_login.dart
+++ b/lib/flutter_login.dart
@@ -322,8 +322,13 @@ class FlutterLogin extends StatefulWidget {
     this.onChangedConfirmPasswordField,
     this.autoValidateModeForm,
     this.onSwitchButton,
+    this.providerLoginAfterSignup = true,
+    this.onChangedRecoverUser,
+    this.onForgotPasswordSwitch,
   })  : assert((logo is String?) || (logo is ImageProvider?)),
         logo = logo is String ? AssetImage(logo) : logo as ImageProvider?;
+
+  final FormFieldValidator<String>? onChangedRecoverUser;
 
   /// Bloc patter flag to make the submitController reactive to a state
   ///
@@ -364,6 +369,14 @@ class FlutterLogin extends StatefulWidget {
   ///
   /// Added to transfer data through forms to blocs when the AuthMode changes
   final VoidCallback? onSwitchButton;
+
+  /// Set to false to return back to sign in page after successful sign up with LoginProvider
+  final bool providerLoginAfterSignup;
+
+  /// Triggered when forgot password button was tapped, to handle states in bloc pattern
+  ///
+  ///
+  final VoidCallback? onForgotPasswordSwitch;
 
   /// Called when the user hit the submit button when in sign up mode
   ///
@@ -909,6 +922,10 @@ class _FlutterLoginState extends State<FlutterLogin>
                         onChangedUserField: widget.onChangedUserField,
                         autoValidateModeForm: widget.autoValidateModeForm,
                         onSwitchButton: widget.onSwitchButton,
+                        providerLoginAfterSignup:
+                            widget.providerLoginAfterSignup,
+                        onChangedRecoverUser: widget.onChangedRecoverUser,
+                        onForgotPasswordSwitch: widget.onForgotPasswordSwitch,
                       ),
                     ),
                     Positioned(

--- a/lib/flutter_login.dart
+++ b/lib/flutter_login.dart
@@ -314,8 +314,26 @@ class FlutterLogin extends StatefulWidget {
     this.headerWidget,
     this.onSwitchToAdditionalFields,
     this.initialIsoCode,
+    this.isBlocPattern = false,
+    this.continueLoginSubmit = false,
+    this.continueSignupSubmit = false,
   })  : assert((logo is String?) || (logo is ImageProvider?)),
         logo = logo is String ? AssetImage(logo) : logo as ImageProvider?;
+
+  /// Bloc patter flag to make the submitController reactive to a state
+  ///
+  ///
+  final bool? isBlocPattern;
+
+  /// Exposing the submitController to state changes for bloc pattern. It requires isBlocPattern flag to be true
+  ///
+  /// Login submit transition animation
+  final bool? continueLoginSubmit;
+
+  /// Exposing the submitController to state changes for bloc pattern. It requires isBlocPattern flag to be true
+  ///
+  /// Singup submit transition animation
+  final bool? continueSignupSubmit;
 
   /// Called when the user hit the submit button when in sign up mode
   ///
@@ -853,6 +871,9 @@ class _FlutterLoginState extends State<FlutterLogin>
                             widget.confirmSignupKeyboardType,
                         introWidget: widget.headerWidget,
                         initialIsoCode: widget.initialIsoCode,
+                        isBlocPattern: widget.isBlocPattern,
+                        continueLoginSubmit: widget.continueLoginSubmit,
+                        continueSignupSubmit: widget.continueSignupSubmit,
                       ),
                     ),
                     Positioned(

--- a/lib/flutter_login.dart
+++ b/lib/flutter_login.dart
@@ -315,11 +315,13 @@ class FlutterLogin extends StatefulWidget {
     this.onSwitchToAdditionalFields,
     this.initialIsoCode,
     this.isBlocPattern = false,
-    this.loginStateController,
+    this.stateController,
     this.signupState = 0,
     this.onChangedUserField,
     this.onChangedPasswordField,
     this.onChangedConfirmPasswordField,
+    this.autoValidateModeForm,
+    this.onSwitchButton,
   })  : assert((logo is String?) || (logo is ImageProvider?)),
         logo = logo is String ? AssetImage(logo) : logo as ImageProvider?;
 
@@ -331,7 +333,7 @@ class FlutterLogin extends StatefulWidget {
   /// Exposing the submitController to state changes for bloc pattern. It requires isBlocPattern flag to be true
   ///
   /// Login submit transition animation
-  final LoginStateController? loginStateController;
+  final StateController? stateController;
 
   /// Exposing the submitController to state changes for bloc pattern. It requires isBlocPattern flag to be true
   ///
@@ -352,6 +354,16 @@ class FlutterLogin extends StatefulWidget {
   ///
   /// Confirm Password Field onChanged logic
   final FormFieldSetter<String>? onChangedConfirmPasswordField;
+
+  /// AutoValidate mode to work together with onChanged fields
+  ///
+  /// If not specified it will work only when the submit button is tapped
+  final AutovalidateMode? autoValidateModeForm;
+
+  /// Additional logic to call when tapping Switch Button
+  ///
+  /// Added to transfer data through forms to blocs when the AuthMode changes
+  final VoidCallback? onSwitchButton;
 
   /// Called when the user hit the submit button when in sign up mode
   ///
@@ -890,11 +902,13 @@ class _FlutterLoginState extends State<FlutterLogin>
                         introWidget: widget.headerWidget,
                         initialIsoCode: widget.initialIsoCode,
                         isBlocPattern: widget.isBlocPattern,
-                        loginStateController: widget.loginStateController,
+                        stateController: widget.stateController,
                         onChangedConfirmPasswordField:
                             widget.onChangedConfirmPasswordField,
                         onChangedPasswordField: widget.onChangedPasswordField,
                         onChangedUserField: widget.onChangedUserField,
+                        autoValidateModeForm: widget.autoValidateModeForm,
+                        onSwitchButton: widget.onSwitchButton,
                       ),
                     ),
                     Positioned(

--- a/lib/flutter_login.dart
+++ b/lib/flutter_login.dart
@@ -315,8 +315,8 @@ class FlutterLogin extends StatefulWidget {
     this.onSwitchToAdditionalFields,
     this.initialIsoCode,
     this.isBlocPattern = false,
-    this.continueLoginSubmit = false,
-    this.continueSignupSubmit = false,
+    this.loginStateController,
+    this.signupState = 0,
   })  : assert((logo is String?) || (logo is ImageProvider?)),
         logo = logo is String ? AssetImage(logo) : logo as ImageProvider?;
 
@@ -328,12 +328,12 @@ class FlutterLogin extends StatefulWidget {
   /// Exposing the submitController to state changes for bloc pattern. It requires isBlocPattern flag to be true
   ///
   /// Login submit transition animation
-  final bool? continueLoginSubmit;
+  final LoginStateController? loginStateController;
 
   /// Exposing the submitController to state changes for bloc pattern. It requires isBlocPattern flag to be true
   ///
   /// Singup submit transition animation
-  final bool? continueSignupSubmit;
+  final int? signupState;
 
   /// Called when the user hit the submit button when in sign up mode
   ///
@@ -872,8 +872,7 @@ class _FlutterLoginState extends State<FlutterLogin>
                         introWidget: widget.headerWidget,
                         initialIsoCode: widget.initialIsoCode,
                         isBlocPattern: widget.isBlocPattern,
-                        continueLoginSubmit: widget.continueLoginSubmit,
-                        continueSignupSubmit: widget.continueSignupSubmit,
+                        loginStateController: widget.loginStateController,
                       ),
                     ),
                     Positioned(

--- a/lib/src/providers/auth.dart
+++ b/lib/src/providers/auth.dart
@@ -144,7 +144,7 @@ class Auth with ChangeNotifier {
   }
 }
 
-class LoginStateController extends ChangeNotifier {
+class StateController extends ChangeNotifier {
   int state = 0;
   void changeState(int value) {
     assert(value >= 0 && value <= 2, throw IndexError);

--- a/lib/src/providers/auth.dart
+++ b/lib/src/providers/auth.dart
@@ -143,3 +143,12 @@ class Auth with ChangeNotifier {
         .toList();
   }
 }
+
+class LoginStateController extends ChangeNotifier {
+  int state = 0;
+  void changeState(int value) {
+    assert(value >= 0 && value <= 2, throw IndexError);
+    state = value;
+    notifyListeners();
+  }
+}

--- a/lib/src/widgets/animated_text_form_field.dart
+++ b/lib/src/widgets/animated_text_form_field.dart
@@ -51,6 +51,7 @@ class AnimatedTextFormField extends StatefulWidget {
     this.validator,
     this.onFieldSubmitted,
     this.onSaved,
+    this.onChanged,
     this.autocorrect = false,
     this.autofillHints,
     this.tooltip,
@@ -81,6 +82,7 @@ class AnimatedTextFormField extends StatefulWidget {
   final FormFieldValidator<String>? validator;
   final ValueChanged<String>? onFieldSubmitted;
   final FormFieldSetter<String>? onSaved;
+  final FormFieldSetter<String>? onChanged;
   final TextFieldInertiaDirection? inertiaDirection;
   final InlineSpan? tooltip;
   final String? initialIsoCode;
@@ -382,6 +384,7 @@ class _AnimatedTextFormFieldState extends State<AnimatedTextFormField> {
         enabled: widget.enabled,
         autocorrect: widget.autocorrect,
         autofillHints: widget.autofillHints,
+        onChanged: widget.onChanged,
       );
     }
 
@@ -458,6 +461,7 @@ class AnimatedPasswordTextFormField extends StatefulWidget {
     this.validator,
     this.onFieldSubmitted,
     this.onSaved,
+    this.onChanged,
     this.autofillHints,
     required this.initialIsoCode,
   }) : assert(
@@ -478,6 +482,7 @@ class AnimatedPasswordTextFormField extends StatefulWidget {
   final FormFieldValidator<String>? validator;
   final ValueChanged<String>? onFieldSubmitted;
   final FormFieldSetter<String>? onSaved;
+  final FormFieldSetter<String>? onChanged;
   final TextFieldInertiaDirection? inertiaDirection;
   final Iterable<String>? autofillHints;
   final String? initialIsoCode;
@@ -539,6 +544,7 @@ class _AnimatedPasswordTextFormFieldState
       validator: widget.validator,
       onFieldSubmitted: widget.onFieldSubmitted,
       onSaved: widget.onSaved,
+      onChanged: widget.onChanged,
       inertiaDirection: widget.inertiaDirection,
       initialIsoCode: widget.initialIsoCode,
     );

--- a/lib/src/widgets/cards/auth_card_builder.dart
+++ b/lib/src/widgets/cards/auth_card_builder.dart
@@ -57,7 +57,9 @@ class AuthCard extends StatefulWidget {
     this.onChangedUserField,
     this.onChangedPasswordField,
     this.onChangedConfirmPasswordField,
-    this.loginStateController,
+    this.stateController,
+    this.autoValidateModeForm,
+    this.onSwitchButton,
   });
 
   final EdgeInsets padding;
@@ -84,10 +86,12 @@ class AuthCard extends StatefulWidget {
   final Widget? introWidget;
   final String? initialIsoCode;
   final bool? isBlocPattern;
-  final LoginStateController? loginStateController;
+  final StateController? stateController;
   final FormFieldSetter<String>? onChangedUserField;
   final FormFieldSetter<String>? onChangedPasswordField;
   final FormFieldSetter<String>? onChangedConfirmPasswordField;
+  final AutovalidateMode? autoValidateModeForm;
+  final VoidCallback? onSwitchButton;
   @override
   AuthCardState createState() => AuthCardState();
 }
@@ -387,10 +391,12 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
             introWidget: widget.introWidget,
             initialIsoCode: widget.initialIsoCode,
             isBlocPattern: widget.isBlocPattern,
-            loginStateController: widget.loginStateController,
+            stateController: widget.stateController,
             onChangedConfirmPasswordField: widget.onChangedConfirmPasswordField,
             onChangedPasswordField: widget.onChangedPasswordField,
             onChangedUserField: widget.onChangedUserField,
+            autoValidateModeForm: widget.autoValidateModeForm,
+            onSwitchButton: widget.onSwitchButton,
           ),
         );
       case _recoveryIndex:

--- a/lib/src/widgets/cards/auth_card_builder.dart
+++ b/lib/src/widgets/cards/auth_card_builder.dart
@@ -53,6 +53,9 @@ class AuthCard extends StatefulWidget {
     required this.confirmSignupKeyboardType,
     this.introWidget,
     required this.initialIsoCode,
+    this.isBlocPattern = false,
+    this.continueLoginSubmit = false,
+    this.continueSignupSubmit = false,
   });
 
   final EdgeInsets padding;
@@ -78,6 +81,9 @@ class AuthCard extends StatefulWidget {
   final TextInputType? confirmSignupKeyboardType;
   final Widget? introWidget;
   final String? initialIsoCode;
+  final bool? isBlocPattern;
+  final bool? continueLoginSubmit;
+  final bool? continueSignupSubmit;
 
   @override
   AuthCardState createState() => AuthCardState();
@@ -377,6 +383,9 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
             hideProvidersTitle: widget.hideProvidersTitle,
             introWidget: widget.introWidget,
             initialIsoCode: widget.initialIsoCode,
+            isBlocPattern: widget.isBlocPattern,
+            continueLoginSubmit: widget.continueLoginSubmit,
+            continueSignupSubmit: widget.continueSignupSubmit,
           ),
         );
       case _recoveryIndex:

--- a/lib/src/widgets/cards/auth_card_builder.dart
+++ b/lib/src/widgets/cards/auth_card_builder.dart
@@ -54,6 +54,9 @@ class AuthCard extends StatefulWidget {
     this.introWidget,
     required this.initialIsoCode,
     this.isBlocPattern = false,
+    this.onChangedUserField,
+    this.onChangedPasswordField,
+    this.onChangedConfirmPasswordField,
     this.loginStateController,
   });
 
@@ -82,7 +85,9 @@ class AuthCard extends StatefulWidget {
   final String? initialIsoCode;
   final bool? isBlocPattern;
   final LoginStateController? loginStateController;
-
+  final FormFieldSetter<String>? onChangedUserField;
+  final FormFieldSetter<String>? onChangedPasswordField;
+  final FormFieldSetter<String>? onChangedConfirmPasswordField;
   @override
   AuthCardState createState() => AuthCardState();
 }
@@ -383,6 +388,9 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
             initialIsoCode: widget.initialIsoCode,
             isBlocPattern: widget.isBlocPattern,
             loginStateController: widget.loginStateController,
+            onChangedConfirmPasswordField: widget.onChangedConfirmPasswordField,
+            onChangedPasswordField: widget.onChangedPasswordField,
+            onChangedUserField: widget.onChangedUserField,
           ),
         );
       case _recoveryIndex:

--- a/lib/src/widgets/cards/auth_card_builder.dart
+++ b/lib/src/widgets/cards/auth_card_builder.dart
@@ -60,6 +60,9 @@ class AuthCard extends StatefulWidget {
     this.stateController,
     this.autoValidateModeForm,
     this.onSwitchButton,
+    this.providerLoginAfterSignup = true,
+    this.onChangedRecoverUser,
+    this.onForgotPasswordSwitch,
   });
 
   final EdgeInsets padding;
@@ -92,6 +95,9 @@ class AuthCard extends StatefulWidget {
   final FormFieldSetter<String>? onChangedConfirmPasswordField;
   final AutovalidateMode? autoValidateModeForm;
   final VoidCallback? onSwitchButton;
+  final bool providerLoginAfterSignup;
+  final FormFieldValidator<String>? onChangedRecoverUser;
+  final VoidCallback? onForgotPasswordSwitch;
   @override
   AuthCardState createState() => AuthCardState();
 }
@@ -397,6 +403,8 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
             onChangedUserField: widget.onChangedUserField,
             autoValidateModeForm: widget.autoValidateModeForm,
             onSwitchButton: widget.onSwitchButton,
+            providerLoginAfterSignup: widget.providerLoginAfterSignup,
+            onForgotPasswordSwitch: widget.onForgotPasswordSwitch,
           ),
         );
       case _recoveryIndex:
@@ -407,6 +415,8 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
           loadingController: formController,
           navigateBack: widget.navigateBackAfterRecovery,
           onBack: () => _changeCard(_loginPageIndex),
+          onChangedRecoverUser: (value) =>
+              widget.onChangedRecoverUser?.call(value),
           onSubmitCompleted: () {
             if (auth.onConfirmRecover != null) {
               _changeCard(_confirmRecover);
@@ -415,6 +425,10 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
             }
           },
           initialIsoCode: widget.initialIsoCode,
+          onForgotPasswordSwitch: widget.onForgotPasswordSwitch,
+          isBlocPattern: widget.isBlocPattern,
+          autoValidateModeForm: widget.autoValidateModeForm,
+          stateController: widget.stateController,
         );
 
       case _additionalSignUpIndex:

--- a/lib/src/widgets/cards/auth_card_builder.dart
+++ b/lib/src/widgets/cards/auth_card_builder.dart
@@ -54,8 +54,7 @@ class AuthCard extends StatefulWidget {
     this.introWidget,
     required this.initialIsoCode,
     this.isBlocPattern = false,
-    this.continueLoginSubmit = false,
-    this.continueSignupSubmit = false,
+    this.loginStateController,
   });
 
   final EdgeInsets padding;
@@ -82,8 +81,7 @@ class AuthCard extends StatefulWidget {
   final Widget? introWidget;
   final String? initialIsoCode;
   final bool? isBlocPattern;
-  final bool? continueLoginSubmit;
-  final bool? continueSignupSubmit;
+  final LoginStateController? loginStateController;
 
   @override
   AuthCardState createState() => AuthCardState();
@@ -384,8 +382,7 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
             introWidget: widget.introWidget,
             initialIsoCode: widget.initialIsoCode,
             isBlocPattern: widget.isBlocPattern,
-            continueLoginSubmit: widget.continueLoginSubmit,
-            continueSignupSubmit: widget.continueSignupSubmit,
+            loginStateController: widget.loginStateController,
           ),
         );
       case _recoveryIndex:

--- a/lib/src/widgets/cards/login_card.dart
+++ b/lib/src/widgets/cards/login_card.dart
@@ -22,6 +22,9 @@ class _LoginCard extends StatefulWidget {
     required this.initialIsoCode,
     this.isBlocPattern = false,
     this.loginStateController,
+    this.onChangedUserField,
+    this.onChangedPasswordField,
+    this.onChangedConfirmPasswordField,
   });
 
   final AnimationController loadingController;
@@ -42,6 +45,9 @@ class _LoginCard extends StatefulWidget {
   final Widget? introWidget;
   final String? initialIsoCode;
   final bool? isBlocPattern;
+  final FormFieldSetter<String>? onChangedUserField;
+  final FormFieldSetter<String>? onChangedPasswordField;
+  final FormFieldSetter<String>? onChangedConfirmPasswordField;
   final LoginStateController? loginStateController;
   @override
   _LoginCardState createState() => _LoginCardState();
@@ -441,6 +447,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
       },
       validator: widget.userValidator,
       onSaved: (value) => auth.email = value!,
+      onChanged: (value) => widget.onChangedUserField?.call(value),
       enabled: !_isSubmitting,
       initialIsoCode: widget.initialIsoCode,
     );
@@ -471,6 +478,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
       },
       validator: widget.passwordValidator,
       onSaved: (value) => auth.password = value!,
+      onChanged: (value) => widget.onChangedPasswordField?.call(value),
       enabled: !_isSubmitting,
       initialIsoCode: widget.initialIsoCode,
     );
@@ -501,6 +509,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
             }
           : (value) => null,
       onSaved: (value) => auth.confirmPassword = value!,
+      onChanged: (value) => widget.onChangedConfirmPasswordField?.call(value),
       initialIsoCode: widget.initialIsoCode,
     );
   }

--- a/lib/src/widgets/cards/recover_card.dart
+++ b/lib/src/widgets/cards/recover_card.dart
@@ -60,7 +60,7 @@ class _RecoverCardState extends State<_RecoverCard>
       duration: const Duration(milliseconds: 1000),
     );
     if (widget.isBlocPattern!) {
-      widget.stateController!.addListener(() => handleRecoverCard());
+      widget.stateController!.addListener(_endSubmit);
     }
   }
 
@@ -68,21 +68,17 @@ class _RecoverCardState extends State<_RecoverCard>
   void dispose() {
     _submitController.dispose();
     if (widget.isBlocPattern!) {
-      widget.stateController!.removeListener(() => handleRecoverCard());
+      widget.stateController!.removeListener(_endSubmit);
     }
     super.dispose();
   }
 
-  void handleRecoverCard() {
+  Future<void> _endSubmit() async {
     if (widget.stateController!.state == failureState ||
         widget.stateController!.state == successfulState && _isSubmitting) {
-      _endSubmit();
+      await _submitController.reverse();
+      setState(() => _isSubmitting = false);
     }
-  }
-
-  Future<void> _endSubmit() async {
-    await _submitController.reverse();
-    setState(() => _isSubmitting = false);
   }
 
   Future<bool> _submit() async {
@@ -93,8 +89,8 @@ class _RecoverCardState extends State<_RecoverCard>
     final messages = Provider.of<LoginMessages>(context, listen: false);
 
     _formRecoverKey.currentState!.save();
-    await _submitController.forward();
     setState(() => _isSubmitting = true);
+    await _submitController.forward();
     if (widget.isBlocPattern!) {
       await auth.onRecoverPassword!(auth.email);
       return true;


### PR DESCRIPTION
Hi again, great work; I had made some changes for it to match with BLoC pattern; if you think that this can be helpful consider on merging or making a secondary tree, since I made some refactors and adding a controller.
Here you can see how I implemented it with firebase_auth.
https://github.com/vcadillog/flutter_firebase_login_bloc_pattern/blob/master/lib/login/view/login_form.dart
Some things to note when isBlocPattern = true (the flag for bloc). It skips all the error handling logic, since I do it in the BLoC repository layer and for that reason I create a Flushbar myself.

Additional changes included, for example in login_form.dart file:
176    await _submitController.forward();
177    setState(() => _isSubmitting = true);
This code potentially leads to a dispose controller error, because if the user taps fast enought the forgot password screen before the setState takes action it disposes the submitController; so I swapped the order to ensure _isSubmitting is true and disable undesired gestures.
