### PR TITLE
fix: Use mounted instead of context.mounted in LoginCard

### DIFF
--- a/lib/src/widgets/cards/login_card.dart
+++ b/lib/src/widgets/cards/login_card.dart
@@ -221,12 +221,12 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
       }
     });
 
-    if (context.mounted) {
+    if (mounted) {
       await _submitController.reverse();
     }
 
     if (!isNullOrEmpty(error)) {
-      if (context.mounted) {
+      if (mounted) {
         showErrorToast(context, messages.flushbarTitleError, error!);
       }
 
@@ -252,7 +252,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
         _switchAuthMode();
         return false;
       } else if (!widget.loginAfterSignUp) {
-        if (context.mounted) {
+        if (mounted) {
           showSuccessToast(
             context,
             messages.flushbarTitleSuccess,
@@ -283,7 +283,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
         // Only show error toast if error is not in exclusion list
         if (loginProvider.errorsToExcludeFromErrorMessage == null ||
             !loginProvider.errorsToExcludeFromErrorMessage!.contains(error)) {
-          if (context.mounted) {
+          if (mounted) {
             showErrorToast(context, messages.flushbarTitleError, error!);
           }
         }
@@ -316,7 +316,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
       // Only show error toast if error is not in exclusion list
       if (loginProvider.errorsToExcludeFromErrorMessage == null ||
           !loginProvider.errorsToExcludeFromErrorMessage!.contains(error)) {
-        if (context.mounted) {
+        if (mounted) {
           showErrorToast(context, messages.flushbarTitleError, error!);
         }
       }
@@ -347,7 +347,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
           // Only show error toast if error is not in exclusion list
           if (loginProvider.errorsToExcludeFromErrorMessage == null ||
               !loginProvider.errorsToExcludeFromErrorMessage!.contains(error)) {
-            if (context.mounted) {
+            if (mounted) {
               showErrorToast(context, messages.flushbarTitleError, error!);
             }
           }


### PR DESCRIPTION
In my [original PR](https://github.com/NearHuscarl/flutter_login/pull/469), I've used mounted instead of context.mounted. However, it was merged as context.mounted checks. The problem is that, context.mounted has [a hidden null check](https://github.com/flutter/flutter/blob/19b06f4ee9a0027b0ece7ae7da783819294e5da8/packages/flutter/lib/src/widgets/framework.dart#L958) in the context getter of the State class. So an issue similar to #468 reappeared again in my crashlytics report. That's why I would like to replace the "context.mounted" checks in the LoginCard component with "mounted".