### PR TITLE
Allow customization of button icon color

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Follow the install instructions [here](https://pub.dev/packages/flutter_login#-i
 | children                              | [`Widget`]                              | <sub>List of widgets that can be added to the stack of the login screen. Can be used to show custom banners or logos. </sub>                                                                                                                           |
 | scrollable                            | `bool`                                  | <sub>When set to true, the login card becomes scrollable instead of resizing when needed.                                                                                                                                                              |
 | headerWidget                          | `Widget`                                | <sub>A widget that can be placed on top of the loginCard.</sub>                                                                                                                                                                                        |
+| autofocus                             | `bool`                                  | <sub>Whether or not to automatically focus on the first field.</sub>                                                                                                                                                                                   |
 
 *NOTE:* It is recommended that the child widget of the `Hero` widget should be the
 same in both places. For title's hero animation use the

--- a/example/lib/login_screen.dart
+++ b/example/lib/login_screen.dart
@@ -59,6 +59,7 @@ class LoginScreen extends StatelessWidget {
       onConfirmRecover: _signupConfirm,
       onConfirmSignup: _signupConfirm,
       loginAfterSignUp: false,
+      autofocus: true,
       loginProviders: [
         LoginProvider(
           button: Buttons.linkedIn,

--- a/lib/flutter_login.dart
+++ b/lib/flutter_login.dart
@@ -314,6 +314,7 @@ class FlutterLogin extends StatefulWidget {
     this.onSwitchToAdditionalFields,
     this.initialIsoCode,
     this.keyboardDismissBehavior = ScrollViewKeyboardDismissBehavior.manual,
+    this.autofocus = false,
   })  : assert((logo is String?) || (logo is ImageProvider?)),
         logo = logo is String ? AssetImage(logo) : logo as ImageProvider?;
 
@@ -461,6 +462,9 @@ class FlutterLogin extends StatefulWidget {
   final String? initialIsoCode;
 
   final ScrollViewKeyboardDismissBehavior keyboardDismissBehavior;
+
+  /// Whether or not to autofocus on the user field
+  final bool autofocus;
 
   static String? defaultEmailValidator(String? value) {
     if (value == null || value.isEmpty || !email.hasMatch(value)) {
@@ -858,6 +862,7 @@ class _FlutterLoginState extends State<FlutterLogin>
                             widget.confirmSignupKeyboardType,
                         introWidget: widget.headerWidget,
                         initialIsoCode: widget.initialIsoCode,
+                        autofocus: widget.autofocus,
                       ),
                     ),
                     Positioned(

--- a/lib/src/providers/login_theme.dart
+++ b/lib/src/providers/login_theme.dart
@@ -5,6 +5,7 @@ class LoginButtonTheme {
     this.backgroundColor,
     this.highlightColor,
     this.splashColor,
+    this.iconColor,
     this.elevation,
     this.highlightElevation,
     this.shape,
@@ -21,6 +22,9 @@ class LoginButtonTheme {
 
   /// The splash color for this button's [InkWell].
   final Color? splashColor;
+
+  /// The color to use for icons. Defaults to [Colors.white]
+  final Color? iconColor;
 
   /// The z-coordinate to be used for the unselected, enabled
   /// button's elevation foreground.

--- a/lib/src/widgets/animated_icon.dart
+++ b/lib/src/widgets/animated_icon.dart
@@ -14,11 +14,13 @@ class AnimatedIconButton extends StatefulWidget {
     required this.icon,
     this.loadingColor,
     this.color,
+    this.iconColor,
   });
 
   final String tooltip;
   final Color? color;
   final Color? loadingColor;
+  final Color? iconColor;
   final VoidCallback onPressed;
   final AnimationController controller;
   final IconData icon;
@@ -200,7 +202,8 @@ class _AnimatedIconButtonState extends State<AnimatedIconButton>
                 width: _height,
                 height: _height,
                 alignment: Alignment.center,
-                child: Icon(widget.icon, color: Colors.white),
+                child:
+                    Icon(widget.icon, color: widget.iconColor ?? Colors.white),
               ),
             ),
           ),

--- a/lib/src/widgets/animated_text_form_field.dart
+++ b/lib/src/widgets/animated_text_form_field.dart
@@ -47,6 +47,7 @@ class AnimatedTextFormField extends StatefulWidget {
     this.textInputAction,
     this.obscureText = false,
     this.controller,
+    this.autofocus = false,
     this.focusNode,
     this.validator,
     this.onFieldSubmitted,
@@ -77,6 +78,7 @@ class AnimatedTextFormField extends StatefulWidget {
   final TextInputAction? textInputAction;
   final bool obscureText;
   final TextEditingController? controller;
+  final bool autofocus;
   final FocusNode? focusNode;
   final FormFieldValidator<String>? validator;
   final ValueChanged<String>? onFieldSubmitted;
@@ -371,6 +373,7 @@ class _AnimatedTextFormFieldState extends State<AnimatedTextFormField> {
       inputField = TextFormField(
         cursorColor: theme.primaryColor,
         controller: widget.controller,
+        autofocus: widget.autofocus,
         focusNode: widget.focusNode,
         decoration: _getInputDecoration(theme),
         keyboardType: widget.keyboardType,

--- a/lib/src/widgets/cards/additional_signup_card.dart
+++ b/lib/src/widgets/cards/additional_signup_card.dart
@@ -201,7 +201,6 @@ class _AdditionalSignUpCardState extends State<_AdditionalSignUpCard>
                       : TextInputAction.next,
               validator: formField.fieldValidator,
               tooltip: formField.tooltip,
-
               initialIsoCode: widget.initialIsoCode,
             ),
             const SizedBox(

--- a/lib/src/widgets/cards/auth_card_builder.dart
+++ b/lib/src/widgets/cards/auth_card_builder.dart
@@ -54,6 +54,7 @@ class AuthCard extends StatefulWidget {
     this.introWidget,
     required this.initialIsoCode,
     this.keyboardDismissBehavior = ScrollViewKeyboardDismissBehavior.manual,
+    required this.autofocus,
   });
 
   final EdgeInsets padding;
@@ -82,6 +83,7 @@ class AuthCard extends StatefulWidget {
   final TextInputType? confirmSignupKeyboardType;
   final Widget? introWidget;
   final String? initialIsoCode;
+  final bool autofocus;
 
   @override
   AuthCardState createState() => AuthCardState();
@@ -381,6 +383,7 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
             hideProvidersTitle: widget.hideProvidersTitle,
             introWidget: widget.introWidget,
             initialIsoCode: widget.initialIsoCode,
+            autofocus: widget.autofocus,
           ),
         );
       case _recoveryIndex:
@@ -399,6 +402,7 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
             }
           },
           initialIsoCode: widget.initialIsoCode,
+          autofocusName: widget.autofocus,
         );
 
       case _additionalSignUpIndex:

--- a/lib/src/widgets/cards/login_card.dart
+++ b/lib/src/widgets/cards/login_card.dart
@@ -23,6 +23,7 @@ class _LoginCard extends StatefulWidget {
     this.hideProvidersTitle = false,
     this.introWidget,
     required this.initialIsoCode,
+    required this.autofocus,
   });
 
   final AnimationController loadingController;
@@ -42,6 +43,7 @@ class _LoginCard extends StatefulWidget {
   final Future<bool> Function() requireSignUpConfirmation;
   final Widget? introWidget;
   final String? initialIsoCode;
+  final bool autofocus;
 
   @override
   _LoginCardState createState() => _LoginCardState();
@@ -386,6 +388,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
       prefixIcon: getPrefixIcon(widget.userType),
       keyboardType: getKeyboardType(widget.userType),
       textInputAction: TextInputAction.next,
+      autofocus: widget.autofocus,
       focusNode: _userFocusNode,
       onFieldSubmitted: (value) {
         FocusScope.of(context).requestFocus(_passwordFocusNode);

--- a/lib/src/widgets/cards/login_card.dart
+++ b/lib/src/widgets/cards/login_card.dart
@@ -633,6 +633,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
                 AnimatedIconButton(
                   color: Colors.transparent,
                   icon: loginProvider.icon!,
+                  iconColor: loginTheme.buttonTheme.iconColor,
                   controller: _providerControllerList[index],
                   tooltip: loginProvider.label,
                   onPressed: () => _loginProviderSubmit(

--- a/lib/src/widgets/cards/recover_card.dart
+++ b/lib/src/widgets/cards/recover_card.dart
@@ -10,6 +10,7 @@ class _RecoverCard extends StatefulWidget {
     required this.onSubmitCompleted,
     required this.loadingController,
     required this.initialIsoCode,
+    required this.autofocusName,
   });
 
   final FormFieldValidator<String>? userValidator;
@@ -21,6 +22,7 @@ class _RecoverCard extends StatefulWidget {
 
   final VoidCallback onSubmitCompleted;
   final String? initialIsoCode;
+  final bool autofocusName;
 
   @override
   _RecoverCardState createState() => _RecoverCardState();
@@ -110,6 +112,7 @@ class _RecoverCardState extends State<_RecoverCard>
       validator: widget.userValidator,
       onSaved: (value) => auth.email = value!,
       initialIsoCode: widget.initialIsoCode,
+      autofocus: widget.autofocusName,
     );
   }
 


### PR DESCRIPTION
Right now the icon color for social login buttons is fixed to white. This allows customization of the icon color.

This isn't fully customizable buttons as requested in https://github.com/NearHuscarl/flutter_login/issues/488, but it may be sufficient for many users who have non-standard color themes.