### PR TITLE
fix: disable the confirm password field while submitting

### DIFF
--- a/lib/src/widgets/cards/login_card.dart
+++ b/lib/src/widgets/cards/login_card.dart
@@ -445,7 +445,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
   ) {
     return AnimatedPasswordTextFormField(
       animatedWidth: width,
-      enabled: auth.isSignup,
+      enabled: !_isSubmitting && auth.isSignup,
       loadingController: widget.loadingController,
       inertiaController: _postSwitchAuthController,
       inertiaDirection: TextFieldInertiaDirection.right,


### PR DESCRIPTION
When the sign up button is pushed, the confirm password field is not disabled. It looks a bit odd as the other two fields are disabled properly.