### PR TITLE
fix: add mounted checks for control.reverse calls

### DIFF
--- a/lib/src/widgets/cards/login_card.dart
+++ b/lib/src/widgets/cards/login_card.dart
@@ -321,7 +321,9 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
     });
 
     if (!isNullOrEmpty(error)) {
-      await control?.reverse();
+      if (mounted) {
+        await control?.reverse();
+      }
 
       // Only show error toast if error is not in exclusion list
       if (loginProvider.errorsToExcludeFromErrorMessage == null ||
@@ -352,7 +354,9 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
             additionalSignupData: auth.additionalSignupData,
           ),
         );
-        await control?.reverse();
+        if (mounted) {
+          await control?.reverse();
+        }
         if (!isNullOrEmpty(error)) {
           // Only show error toast if error is not in exclusion list
           if (loginProvider.errorsToExcludeFromErrorMessage == null ||
@@ -370,12 +374,16 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
           return false;
         }
       }
-      await control?.reverse();
+      if (mounted) {
+        await control?.reverse();
+      }
       widget.onSwitchSignUpAdditionalData();
     } else {
       widget.onSubmitCompleted?.call();
     }
-    await control?.reverse();
+    if (mounted) {
+      await control?.reverse();
+    }
     return true;
   }
 


### PR DESCRIPTION
I use this package in our mobile / desktop apps and our telemetry detected the following crash.

```
Null check operator used on a null value

#0      AnimationController.stop (package:flutter/src/animation/animation_controller.dart:899)
#1      AnimationController._animateToInternal (package:flutter/src/animation/animation_controller.dart:673)
#2      AnimationController.reverse (package:flutter/src/animation/animation_controller.dart:521)
#3      _LoginCardState._loginProviderSubmit (package:flutter_login/src/widgets/cards/login_card.dart:324)
<asynchronous suspension>
```

I would like to fix it by adding the mounted checks.