### PR TITLE
Fix null check error in _forwardChangeRouteAnimation

### DIFF
--- a/lib/src/widgets/cards/auth_card_builder.dart
+++ b/lib/src/widgets/cards/auth_card_builder.dart
@@ -310,6 +310,11 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
   }
 
   Future<void> _forwardChangeRouteAnimation(GlobalKey cardKey) {
+    if (!mounted) {
+      widget.onSubmit?.call();
+      return Future.value();
+    }
+
     final deviceSize = MediaQuery.of(context).size;
 
     // Get card size, or use default size so that the animation wont crash.

--- a/lib/src/widgets/cards/login_card.dart
+++ b/lib/src/widgets/cards/login_card.dart
@@ -321,7 +321,9 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
     });
 
     if (!isNullOrEmpty(error)) {
-      await control?.reverse();
+      if (mounted) {
+        await control?.reverse();
+      }
 
       // Only show error toast if error is not in exclusion list
       if (loginProvider.errorsToExcludeFromErrorMessage == null ||
@@ -352,7 +354,9 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
             additionalSignupData: auth.additionalSignupData,
           ),
         );
-        await control?.reverse();
+        if (mounted) {
+          await control?.reverse();
+        }
         if (!isNullOrEmpty(error)) {
           // Only show error toast if error is not in exclusion list
           if (loginProvider.errorsToExcludeFromErrorMessage == null ||
@@ -370,12 +374,16 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
           return false;
         }
       }
-      await control?.reverse();
+      if (mounted) {
+        await control?.reverse();
+      }
       widget.onSwitchSignUpAdditionalData();
     } else {
       widget.onSubmitCompleted?.call();
     }
-    await control?.reverse();
+    if (mounted) {
+      await control?.reverse();
+    }
     return true;
   }
 


### PR DESCRIPTION
I use this package in our mobile / desktop apps and our telemetry detected the following crash.

```
Null check operator used on a null value

#0      State.context (package:flutter/src/widgets/framework.dart:959)
#1      AuthCardState._forwardChangeRouteAnimation (package:flutter_login/src/widgets/cards/auth_card_builder.dart:313)
#2      AuthCardState._changeToCard.<anonymous closure> (package:flutter_login/src/widgets/cards/auth_card_builder.dart:457)
#3      _LoginCardState._loginProviderSubmit (package:flutter_login/src/widgets/cards/login_card.dart:376)
<asynchronous suspension>
```

I would like to fix it by adding the mounted checks.